### PR TITLE
Api provides client with an endpoint for a single article

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem 'bootsnap', '>= 1.4.4', require: false
 gem 'rack-cors', require: 'rack/cors'
 gem 'active_model_serializers'
 gem 'devise_token_auth', github: 'lynndylanhurley/devise_token_auth', branch: 'master'
+gem 'faker', git: 'https://github.com/faker-ruby/faker.git', branch: 'master'
 
 group :development, :test do
   gem 'shoulda-matchers'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,12 @@
 GIT
+  remote: https://github.com/faker-ruby/faker.git
+  revision: 1c1b56178cf6aabddfdaffcf879bbf94b2725812
+  branch: master
+  specs:
+    faker (2.18.0)
+      i18n (>= 1.6, < 2)
+
+GIT
   remote: https://github.com/lynndylanhurley/devise_token_auth.git
   revision: 7d21928324aa5275039f13fa15fc20a759c6838a
   branch: master
@@ -235,6 +243,7 @@ DEPENDENCIES
   coveralls
   devise_token_auth!
   factory_bot_rails
+  faker!
   listen (~> 3.3)
   pg (~> 1.1)
   pry-rails

--- a/app/controllers/api/articles_controller.rb
+++ b/app/controllers/api/articles_controller.rb
@@ -9,7 +9,11 @@ class Api::ArticlesController < ApplicationController
   end 
 
   def show
+    begin
     article = Article.find(params[:id])
     render json: article, serializer: ArticlesShowSerializer
+    rescue ActiveRecord::RecordNotFound => e
+      render json: {error_message: 'Article does not exist'}, status: 404
+    end
   end 
 end

--- a/app/controllers/api/articles_controller.rb
+++ b/app/controllers/api/articles_controller.rb
@@ -10,8 +10,8 @@ class Api::ArticlesController < ApplicationController
 
   def show
     begin
-    article = Article.find(params[:id])
-    render json: article, serializer: ArticlesShowSerializer
+      article = Article.find(params[:id])
+      render json: article, serializer: ArticlesShowSerializer
     rescue ActiveRecord::RecordNotFound => e
       render json: {error_message: 'Article does not exist'}, status: 404
     end

--- a/app/controllers/api/articles_controller.rb
+++ b/app/controllers/api/articles_controller.rb
@@ -10,6 +10,6 @@ class Api::ArticlesController < ApplicationController
 
   def show
     article = Article.find(params[:id])
-    render json: {article: article}
+    render json: article, serializer: ArticlesShowSerializer
   end 
 end

--- a/app/controllers/api/articles_controller.rb
+++ b/app/controllers/api/articles_controller.rb
@@ -6,5 +6,10 @@ class Api::ArticlesController < ApplicationController
     else
       render json: articles, each_serializer: ArticlesIndexSerializer
     end
-  end
+  end 
+
+  def show
+    article = Article.find(params[:id])
+    render json: {article: article}
+  end 
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,4 +1,4 @@
 class Article < ApplicationRecord
-  validates_presence_of :title, :teaser
+  validates_presence_of :title, :teaser, :body
   scope :most_recent, -> { order(created_at: :desc)}
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,4 +1,5 @@
 class Article < ApplicationRecord
   validates_presence_of :title, :teaser, :body
   scope :most_recent, -> { order(created_at: :desc)}
+  belongs_to :user
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,4 +9,6 @@ class User < ActiveRecord::Base
   include DeviseTokenAuth::Concerns::User
 
   enum role: { member: 1, journalist: 5 }
+
+  has_many :articles
 end

--- a/app/serializers/articles_index_serializer.rb
+++ b/app/serializers/articles_index_serializer.rb
@@ -2,6 +2,6 @@ class ArticlesIndexSerializer < ActiveModel::Serializer
   attributes :id, :title, :teaser, :date
 
   def date
-    object.created_at.strftime('%F')
+    object.created_at.strftime('%F, %H:%M')
   end
 end

--- a/app/serializers/articles_show_serializer.rb
+++ b/app/serializers/articles_show_serializer.rb
@@ -1,0 +1,7 @@
+class ArticlesShowSerializer < ActiveModel::Serializer
+  attributes :id, :title, :body, :date
+  
+  def date
+    object.created_at.strftime('%F')
+  end
+end

--- a/app/serializers/articles_show_serializer.rb
+++ b/app/serializers/articles_show_serializer.rb
@@ -9,6 +9,6 @@ class ArticlesShowSerializer < ActiveModel::Serializer
   end
 
   def date
-    object.created_at.strftime('%F')
+    object.created_at.strftime('%F, %H:%M')
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,6 @@ Rails.application.routes.draw do
     sessions: 'api/sessions'
   }
   namespace :api do
-    resources :articles, only: [:index]
+    resources :articles, only: [:index, :show]
   end
 end

--- a/db/migrate/20210513125025_add_body_to_article.rb
+++ b/db/migrate/20210513125025_add_body_to_article.rb
@@ -1,0 +1,5 @@
+class AddBodyToArticle < ActiveRecord::Migration[6.1]
+  def change
+    add_column :articles, :body, :text
+  end
+end

--- a/db/migrate/20210513132303_create_relationshop_between_article_and_user.rb
+++ b/db/migrate/20210513132303_create_relationshop_between_article_and_user.rb
@@ -1,0 +1,5 @@
+class CreateRelationshopBetweenArticleAndUser < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :articles, :user, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_13_125025) do
+ActiveRecord::Schema.define(version: 2021_05_13_132303) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,6 +21,8 @@ ActiveRecord::Schema.define(version: 2021_05_13_125025) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.text "body"
+    t.bigint "user_id"
+    t.index ["user_id"], name: "index_articles_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -53,4 +55,5 @@ ActiveRecord::Schema.define(version: 2021_05_13_125025) do
     t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
   end
 
+  add_foreign_key "articles", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_13_120815) do
+ActiveRecord::Schema.define(version: 2021_05_13_125025) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,6 +20,7 @@ ActiveRecord::Schema.define(version: 2021_05_13_120815) do
     t.text "teaser"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.text "body"
   end
 
   create_table "users", force: :cascade do |t|

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -3,5 +3,6 @@ FactoryBot.define do
     title { "First title" }
     teaser { "some text" }
     body { "Husband found dead allegedly because he wasn't testing first" }
+    association :user
   end
 end

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -2,5 +2,6 @@ FactoryBot.define do
   factory :article do
     title { "First title" }
     teaser { "some text" }
+    body { "Husband found dead allegedly because he wasn't testing first" }
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :user do
-    email { 'random@randon.com' }
+    email { "#{rand(10000000000)}random@randon.com" }
     password { 'password' }
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,6 +1,8 @@
+require 'faker'
+
 FactoryBot.define do
   factory :user do
-    email { "#{rand(10000000000)}random@randon.com" }
+    email { Faker::Internet.email }
     password { 'password' }
     first_name { "Mr." }
     last_name { "Fake" }

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -4,11 +4,13 @@ RSpec.describe Article, type: :model do
   describe 'db table' do
     it { is_expected.to have_db_column(:title).of_type(:string) }
     it { is_expected.to have_db_column(:teaser).of_type(:text) }
+    it { is_expected.to have_db_column(:body).of_type(:text) }
   end
 
   describe 'Validation' do
     it { is_expected.to validate_presence_of :title }
     it { is_expected.to validate_presence_of :teaser }
+    it { is_expected.to validate_presence_of :body }
   end
 
   describe 'Factory' do

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -13,6 +13,10 @@ RSpec.describe Article, type: :model do
     it { is_expected.to validate_presence_of :body }
   end
 
+  describe 'Relationship between article and user' do
+    it { is_expected.to belong_to(:user) }
+  end
+
   describe 'Factory' do
     it 'is expected to have valid Factory' do
       expect(create(:article)).to be_valid

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -7,6 +7,10 @@ RSpec.describe User, type: :model do
     it { is_expected.to define_enum_for(:role).with_values({ member: 1, journalist: 5 }) }
   end
 
+  describe 'Relationship between article and user' do
+    it { is_expected.to have_many(:articles) }
+  end
+
   describe 'factory' do
     it 'is expected to have a default factory' do
       expect(create(:user)).to be_valid

--- a/spec/requests/api/can_responde_with_list_of_articles_spec.rb
+++ b/spec/requests/api/can_responde_with_list_of_articles_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'GET /api/articles', type: :request do
     end
 
     it 'is expected to contain dates in a readable format' do
-      expect(response_json['articles'].first['date']).to eq Time.now.strftime('%F')
+      expect(response_json['articles'].first['date']).to eq Time.now.strftime('%F, %H:%M')
     end
 
     it 'is expected to return lists with newest articles first' do

--- a/spec/requests/api/can_show_single_article_spec.rb
+++ b/spec/requests/api/can_show_single_article_spec.rb
@@ -1,0 +1,46 @@
+RSpec.describe "GET /api/articles/:id" do
+  let!(:article) { create(:article)}
+  describe "successfully" do
+    before do
+      get "/api/articles/#{article.id}"
+    end
+
+    it "is expected to return 200 status" do
+      expect(response).to have_http_status 200
+    end
+
+    it "is expected to return title" do
+      expect(response_json["article"]["title"]).to eq "First title"
+    end
+
+    it "is expected to return body" do
+      expect(response_json["article"]["body"]).to eq "Husband found dead allegedly because he wasn't testing first"
+    end
+
+    it "is expected to return date" do
+      expect(response_json["article"]["date"]).to eq Time.now.strftime("%F")
+    end
+
+    it "is expected to include author's first name" do
+      expect(response_json["article"]["author"]["first_name"]).to eq "Melon"
+    end
+
+    it "is expected to include author's last name" do
+      expect(response_json["article"]["author"]["last_name"]).to eq "Usk"
+    end
+  end
+
+  describe 'unsuccessfully with no article' do
+    before do
+      get '/api/articles/123'
+    end
+
+    it 'is expected to response with status 404' do
+      expect(response).to have_http_status 404
+    end
+
+    it 'is expected to have error message' do
+      expect(response_json['error_message']).to eq 'Article does not exist'
+    end
+  end
+end

--- a/spec/requests/api/can_show_single_article_spec.rb
+++ b/spec/requests/api/can_show_single_article_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "GET /api/articles/:id" do
     end
 
     it "is expected to return date" do
-      expect(response_json["article"]["date"]).to eq Time.now.strftime("%F")
+      expect(response_json["article"]["date"]).to eq Time.now.strftime("%F, %H:%M")
     end
 
     it "is expected to include author's first name" do


### PR DESCRIPTION
[**PT-Story:** ](https://www.pivotaltracker.com/story/show/178091982)
### User Story 
``` 
As an Api
In order to present the client with details of a single article including author's name
I would like to send a specific article from our database
``` 
## Changes proposed in this pull request: 
* Adds show action for Articles
* Adds body attribute to Article
* Adds association between Article and User models
* Adds author to the show action serializer
* Updates Semaphore file
## What I have learned working on this feature: 
* How to use Serializer to add an author
* How to create a relationship between two models
* begin & rescue practice
