### PR TITLE
Api provides admin functionality so that journalists can see their own articles

### DIFF
--- a/app/controllers/api/articles_controller.rb
+++ b/app/controllers/api/articles_controller.rb
@@ -6,18 +6,11 @@ class Api::ArticlesController < ApplicationController
     articles = Article.all.most_recent
     if current_user&.journalist?
       articles_by_journalist = Article.where(user_id: current_user.id).most_recent
-      render json: {articles: []}, status: 200 and return if articles_by_journalist == []
       render json: articles_by_journalist, each_serializer: ArticlesIndexSerializer and return
     end
-    if articles == []
-      render json: {articles: []}, status: 200
-    elsif params[:category]
+    if params[:category]
       articles_by_category = Article.where(category: params[:category])
-      if articles_by_category == []
-        render json: { error_message: 'There is no Articles in this category' }, status: 404
-      else
-        render json: articles_by_category, each_serializer: ArticlesIndexSerializer
-      end
+      render json: articles_by_category, each_serializer: ArticlesIndexSerializer
     else
       render json: articles, each_serializer: ArticlesIndexSerializer
     end
@@ -49,7 +42,6 @@ class Api::ArticlesController < ApplicationController
 
   def role_authenticator
     return if current_user.journalist?
-
     render json: { error_message: 'You are not authorized to create an article' }, status: 403
   end
 end

--- a/app/controllers/api/articles_controller.rb
+++ b/app/controllers/api/articles_controller.rb
@@ -1,9 +1,13 @@
 class Api::ArticlesController < ApplicationController
-  before_action :authenticate_user!, only: [:create]
-  before_action :role_authenticator, only: [:create]
+  before_action :authenticate_user!, only: %i[create index]
+  before_action :role_authenticator, only: %i[create index]
 
   def index
     articles = Article.all.most_recent
+    unless current_user.role == 'journalist'
+      article_by_journalist = Article.where(user_id: current_user.id)
+      render json: {article_by_journalist: current_user.id}
+    end
     if articles == []
       render json: { articles: articles }, status: 204
     elsif params[:category]
@@ -35,6 +39,8 @@ class Api::ArticlesController < ApplicationController
   end
 
   private
+
+  def method_name; end
 
   def article_params
     params[:article].permit(:title, :teaser, :body, :category)

--- a/app/controllers/api/articles_controller.rb
+++ b/app/controllers/api/articles_controller.rb
@@ -19,7 +19,6 @@ class Api::ArticlesController < ApplicationController
       end
     else
       render json: articles, each_serializer: ArticlesIndexSerializer
-
     end
   end
 
@@ -50,6 +49,6 @@ class Api::ArticlesController < ApplicationController
   def role_authenticator
     return if current_user.journalist?
 
-    render json: { error_message: 'You are not authorized to create an article' }, status: 403 
+    render json: { error_message: 'You are not authorized to create an article' }, status: 403
   end
 end

--- a/app/controllers/api/articles_controller.rb
+++ b/app/controllers/api/articles_controller.rb
@@ -6,12 +6,12 @@ class Api::ArticlesController < ApplicationController
     articles = Article.all.most_recent
     if current_user&.journalist?
       articles_by_journalist = Article.where(user_id: current_user.id).most_recent
-      render json: {}, status: 204 and return if articles_by_journalist == []
+      render json: {}, status: 200 and return if articles_by_journalist == []
 
       render json: articles_by_journalist, each_serializer: ArticlesIndexSerializer and return
     end
     if articles == []
-      render json: {}, status: 204
+      render json: {}, status: 200
     elsif params[:category]
       articles_by_category = Article.where(category: params[:category])
       if articles_by_category == []

--- a/app/controllers/api/articles_controller.rb
+++ b/app/controllers/api/articles_controller.rb
@@ -6,12 +6,11 @@ class Api::ArticlesController < ApplicationController
     articles = Article.all.most_recent
     if current_user&.journalist?
       articles_by_journalist = Article.where(user_id: current_user.id).most_recent
-      render json: {}, status: 200 and return if articles_by_journalist == []
-
+      render json: {articles: []}, status: 200 and return if articles_by_journalist == []
       render json: articles_by_journalist, each_serializer: ArticlesIndexSerializer and return
     end
     if articles == []
-      render json: {}, status: 200
+      render json: {articles: []}, status: 200
     elsif params[:category]
       articles_by_category = Article.where(category: params[:category])
       if articles_by_category == []

--- a/app/controllers/api/articles_controller.rb
+++ b/app/controllers/api/articles_controller.rb
@@ -6,10 +6,12 @@ class Api::ArticlesController < ApplicationController
     articles = Article.all.most_recent
     if current_user&.journalist?
       articles_by_journalist = Article.where(user_id: current_user.id).most_recent
+      render json: {}, status: 204 and return if articles_by_journalist == []
+
       render json: articles_by_journalist, each_serializer: ArticlesIndexSerializer and return
     end
     if articles == []
-      render json: { articles: articles }, status: 204
+      render json: {}, status: 204
     elsif params[:category]
       articles_by_category = Article.where(category: params[:category])
       if articles_by_category == []

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -20,9 +20,9 @@ ActiveRecord::Schema.define(version: 2021_05_13_144254) do
     t.text "teaser"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.string "category"
     t.text "body"
     t.bigint "user_id"
+    t.string "category"
     t.index ["user_id"], name: "index_articles_on_user_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,25 +2,40 @@ titles = [
   'New Vaccine Conspiracy Theories Are Going Viral in Arabic',
   '‘It is a trap!’: Inside the QAnon attack that never happened',
   'New Year 2020: 10 Moments This Decade That Made Us Say, "Wait, What?"',
-"Amateur Rocket-Maker Finally Launches Himself Off Earth - Now To Prove It's Flat"
+  "Amateur Rocket-Maker Finally Launches Himself Off Earth - Now To Prove It's Flat",
+  'The Covid-19 Vaccine Will Contain A Microchip',
+  'Canada SWAT team arrest pastor Artur Pawlowski, who’s been holding church services in defiance of the country’s strict COVID lockdown measures.',
+  'Moderna Chief Medical Officer Confirms mRNA Injection For COVID-19 Can Change Your Genetic Code.'
+
 ]
 teasers = [
   'Facebook has been criticized for failing to curb misinformation in English. But little attention has been paid to the scale of the problem in Arabic.',
-'Why fears of violence on March 4, the mythical day Trump was supposed to be inaugurated to a second term, proved unfounded.',
-'Happy New Year 2020: This list of ten moments includes not just personalities in India and across the world, but also certain events which have had a number of consequences for those involved.',
-'Mike Hughes, a California man who is most known for his belief that the Earth is shaped like a Frisbee, finally blasted off into the sky in a steam-powered rocket he had built himself.'
+  'Why fears of violence on March 4, the mythical day Trump was supposed to be inaugurated to a second term, proved unfounded.',
+  'Happy New Year 2020: This list of ten moments includes not just personalities in India and across the world, but also certain events which have had a number of consequences for those involved.',
+  'Mike Hughes, a California man who is most known for his belief that the Earth is shaped like a Frisbee, finally blasted off into the sky in a steam-powered rocket he had built himself.',
+  'Despite the majority of us keeping our fingers crossed for a Covid-19 vaccine to be developed as soon as possible, others on the internet are sceptical about the benefits of a such a cure.',
+  'Several police vehicles surrounded Pawlowski after he finished a service on Saturday, ordered him out of his car and made him kneel down on a busy highway to arrest him.',
+  'From a TEDx Beacon Street talk occurred in 2017, Tal Zaks, chief medical officer of Moderna, Inc., one pharmaceutical company manufacturer of the experimental mRNA technology injection, confirms mRNA injection for COVID-19 can change your genetic code or DNA.'
 ]
-
-body =
+body = [
   'Science gets a lot of respect these days. Unfortunately, it’s also getting a lot of competition from misinformation. Seven in 10 Americans think the benefits from science outweigh the harms, and nine in 10 think science and technology will create more opportunities for future generations. Scientists have made dramatic progress in understanding the universe and the mechanisms of biology, and advances in computation benefit all fields of science.
-  On the other hand, Americans are surrounded by a rising tide of misinformation and fake science. Take climate change. Scientists are in almost complete agreement that people are the primary cause of global warming. Yet polls show that a third of the public disagrees with this conclusion.
-  
-  In my 30 years of studying and promoting scientific literacy, I’ve found that college educated adults have large holes in their basic science knowledge and they’re disconcertingly susceptible to superstition and beliefs that aren’t based on any evidence. One way to counter this is to make it easier for people to detect pseudoscience online. To this end, my lab at the University of Arizona has developed an artificial intelligence-based pseudoscience detector that we plan to freely release as a web browser extension and smart phone app.'
+  In my 30 years of studying and promoting scientific literacy, I’ve found that college educated adults have large holes in their basic science knowledge and they’re disconcertingly susceptible to superstition and beliefs that aren’t based on any evidence. One way to counter this is to make it easier for people to detect pseudoscience online. To this end, my lab at the University of Arizona has developed an artificial intelligence-based pseudoscience detector that we plan to freely release as a web browser extension and smart phone app.',
+  'In a joint intelligence bulletin earlier this week, the FBI and Department of Homeland Security delivered a jarring warning to state and local law enforcement: violent domestic extremists motivated by the QAnon conspiracy theory might be mobilized to action because they believed Donald Trump would be inaugurated on March 4.',
+  'New Delhi: As this decade comes to an end, there have been quite a few moments that people have hoped and prayed had never happened. While these \'foot-in-mouth\' moments have numbered in the hundreds and thousands in this decade itself, we\'ve rounded up ten of the choicest moments, some of them quite embarrassing for those concerned.',
+  "The 61-year-old limo driver and daredevil-turned-rocket-maker soared about 1,875 feet above the Mojave Desert on Saturday afternoon, the Associated Press reported. Hughes\'s white-and-green rocket, bearing the words 'FLAT EARTH,' propelled vertically about 3 p.m. Pacific time and reached a speed of about 350 mph, Waldo Stakes, who has been helping Hughes, told the AP. Hughes deployed two parachutes while landing, the second one just moments before he plopped down not far from his launching point.",
+  "In fact, Youtuber David Icke claimed that a coronavirus vaccine, when there is one, will contain 'nanotechnology microchips' that would in theory allow humans to be controlled.",
+  'Hello friends, this is pastor Artur Pawlowksi. If you\'re watching this video, it means they have successfully arrested me and I am in jail, he said, then asking for support for his legal battle ahead.',
+  'An article shared thousands of times on social media claims that Tal Zaks, the chief medical officer of US pharma firm Moderna, said messenger RNA vaccines can "alter" human DNA. The posts, which circulated online as Moderna’s mRNA Covid-19 vaccine was administered to millions of people around the world, claim Zaks made the comments during a TEDx Talk. The claim is false: Zaks did not make the purported comments. Scientists have previously rejected false claims that mRNA vaccines can alter DNA.
+  “Bombshell: Moderna Chief Medical Officer Admits MRNA Alters DNA,” reads the screenshot of an article shared on Twitter on March 20, 2021.
+  The post links to an article on US website DC Dirty Laundry.'
+]
 
 categories = ['Flat Earth', 'Aliens', 'Covid', 'Illuminati', 'Politics', 'Hollywood']
 
-user = User.create(email: 'mrfake@fakenews.com', password: 'password', password_confirmation: 'password', first_name: 'Mr.', last_name: 'Fake', role: 5)
+user = User.create(email: 'mrfake@fakenews.com', password: 'password', password_confirmation: 'password',
+                   first_name: 'Mr.', last_name: 'Fake', role: 5)
 
-for i in 0...titles.count
-  Article.create(title: titles[i], teaser: teasers[i], body: body, category: categories[rand(categories.count-1)], user_id: user.id)
-end 
+(0...titles.count).each do |i|
+  Article.create(title: titles[i], teaser: teasers[i], body: body, category: categories[rand(categories.count - 1)],
+                 user_id: user.id)
+end

--- a/spec/requests/api/auth/journalist_can_see_thier_own_articles_spec.rb
+++ b/spec/requests/api/auth/journalist_can_see_thier_own_articles_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe 'GET /api/articles', type: :request do
   let!(:journalist) { create(:user, role: 'journalist') }
-  let!(:article1) { create(:article, title: 'First Article' , user_id: journalist.id)  }
+  let!(:article1) { create(:article, title: 'First Article', user_id: journalist.id) }
   let!(:article2) { create(:article, title: 'Second Article', user_id: journalist.id) }
   let!(:article3) { create(:article, title: 'Third Article') }
   let!(:article4) { create(:article, title: 'Fourth Article') }
@@ -9,14 +9,6 @@ RSpec.describe 'GET /api/articles', type: :request do
   describe 'successfully' do
     before do
       get '/api/articles',
-          params: {
-            article: {
-              title: 'Obnoxious Title',
-              teaser: 'Some damn teaser',
-              body: "Husband found dead allegedly because he wasn't testing first",
-              category: 'Hollywood'
-            }
-          },
           headers: auth_headers
     end
 
@@ -31,5 +23,16 @@ RSpec.describe 'GET /api/articles', type: :request do
     it 'article belongs to expected journalist' do
       expect(response_json['articles'].first['title']).to eq 'Second Article'
     end
+  end
+  describe 'unsuccessfully because journalist does not have any article' do
+    before do
+      get '/api/articles',
+          headers: auth_headers
+    end
+
+    it 'is expected to response with status 204' do
+      expect(response).to have_http_status 204
+    end
+
   end
 end

--- a/spec/requests/api/auth/journalist_can_see_thier_own_articles_spec.rb
+++ b/spec/requests/api/auth/journalist_can_see_thier_own_articles_spec.rb
@@ -1,12 +1,12 @@
 RSpec.describe 'GET /api/articles', type: :request do
   let!(:journalist) { create(:user, role: 'journalist') }
-  let!(:article1) { create(:article, title: 'First Article', user_id: journalist.id) }
-  let!(:article2) { create(:article, title: 'Second Article', user_id: journalist.id) }
-  let!(:article3) { create(:article, title: 'Third Article') }
-  let!(:article4) { create(:article, title: 'Fourth Article') }
   let(:auth_headers) { journalist.create_new_auth_token }
 
   describe 'successfully' do
+    let!(:article1) { create(:article, title: 'First Article', user_id: journalist.id) }
+    let!(:article2) { create(:article, title: 'Second Article', user_id: journalist.id) }
+    let!(:article3) { create(:article, title: 'Third Article') }
+    let!(:article4) { create(:article, title: 'Fourth Article') }
     before do
       get '/api/articles',
           headers: auth_headers

--- a/spec/requests/api/auth/journalist_can_see_thier_own_articles_spec.rb
+++ b/spec/requests/api/auth/journalist_can_see_thier_own_articles_spec.rb
@@ -5,8 +5,6 @@ RSpec.describe 'GET /api/articles', type: :request do
   describe 'successfully' do
     let!(:article1) { create(:article, title: 'First Article', user_id: journalist.id) }
     let!(:article2) { create(:article, title: 'Second Article', user_id: journalist.id) }
-    let!(:article3) { create(:article, title: 'Third Article') }
-    let!(:article4) { create(:article, title: 'Fourth Article') }
     before do
       get '/api/articles',
           headers: auth_headers
@@ -20,19 +18,20 @@ RSpec.describe 'GET /api/articles', type: :request do
       expect(response_json['articles'].count).to eq 2
     end
 
-    it 'article belongs to expected journalist' do
+    it 'is expected to return articles sorted by most recent' do
       expect(response_json['articles'].first['title']).to eq 'Second Article'
     end
   end
   describe 'unsuccessfully because journalist does not have any article' do
+    let!(:article3) { create(:article, title: 'Third Article') }
+    let!(:article4) { create(:article, title: 'Fourth Article') }
     before do
       get '/api/articles',
           headers: auth_headers
     end
 
-    it 'is expected to response with status 204' do
-      expect(response).to have_http_status 204
+    it 'is expected to response with status 200' do
+      expect(response).to have_http_status 200
     end
-
   end
 end

--- a/spec/requests/api/auth/journalist_can_see_thier_own_articles_spec.rb
+++ b/spec/requests/api/auth/journalist_can_see_thier_own_articles_spec.rb
@@ -1,0 +1,33 @@
+RSpec.describe 'GET /api/articles', type: :request do
+  let!(:journalist1) { 2.times { create(:user, role: 'journalist') { :article1 } } }
+  let!(:journalist2) { 2.times { create(:user, role: 'journalist') { :article2 } } }
+  let(:auth_headers) { journalist1.create_new_auth_token }
+  let(:auth_headers) { journalist2.create_new_auth_token }
+
+  describe 'successfully' do
+    before do
+      get '/api/articles',
+          params: {
+            article: {
+              title: 'Obnoxious Title',
+              teaser: 'Some damn teaser',
+              body: "Husband found dead allegedly because he wasn't testing first",
+              category: 'Hollywood'
+            }
+          },
+          headers: auth_headers
+    end
+
+    it 'is expected to response with status 200' do
+      expect(response).to have_http_status 200
+    end
+
+    it 'is expected to return 2 articles to the right journalist' do
+      expect(response_json['articles']['role'].count).to eq 2
+    end
+
+    it 'is expected to have the category that we ask for' do
+      expect(response_json['articles'].first['category']).to eq 'Flat Earth'
+    end
+  end
+end

--- a/spec/requests/api/auth/journalist_can_see_thier_own_articles_spec.rb
+++ b/spec/requests/api/auth/journalist_can_see_thier_own_articles_spec.rb
@@ -1,12 +1,10 @@
 RSpec.describe 'GET /api/articles', type: :request do
-  let(:journalist1) { create(:user, role: 'journalist') }
-  let!(:journalist2) { create(:user, role: 'journalist') }
-  let!(:article1) { create(:article, title: 'Second Article') }
-  let!(:article2) { create(:article, title: 'First Article') }
+  let!(:journalist) { create(:user, role: 'journalist') }
+  let!(:article1) { create(:article, title: 'First Article' , user_id: journalist.id)  }
+  let!(:article2) { create(:article, title: 'Second Article', user_id: journalist.id) }
   let!(:article3) { create(:article, title: 'Third Article') }
   let!(:article4) { create(:article, title: 'Fourth Article') }
-  let(:auth_headers) { journalist1.create_new_auth_token }
-  let(:auth_headers) { journalist2.create_new_auth_token }
+  let(:auth_headers) { journalist.create_new_auth_token }
 
   describe 'successfully' do
     before do
@@ -27,11 +25,11 @@ RSpec.describe 'GET /api/articles', type: :request do
     end
 
     it 'is expected to return 2 articles to the right journalist' do
-      expect(response_json['articles']['role'].count).to eq 2
+      expect(response_json['articles'].count).to eq 2
     end
 
-    it 'is expected to have the category that we ask for' do
-      expect(response_json['articles'].first['category']).to eq 'Flat Earth'
+    it 'article belongs to expected journalist' do
+      expect(response_json['articles'].first['title']).to eq 'Second Article'
     end
   end
 end

--- a/spec/requests/api/auth/journalist_can_see_thier_own_articles_spec.rb
+++ b/spec/requests/api/auth/journalist_can_see_thier_own_articles_spec.rb
@@ -33,5 +33,9 @@ RSpec.describe 'GET /api/articles', type: :request do
     it 'is expected to response with status 200' do
       expect(response).to have_http_status 200
     end
+
+    it 'is expected to return an empty array' do
+      expect(response_json['articles']).to eq []
+    end
   end
 end

--- a/spec/requests/api/auth/journalist_can_see_thier_own_articles_spec.rb
+++ b/spec/requests/api/auth/journalist_can_see_thier_own_articles_spec.rb
@@ -1,6 +1,10 @@
 RSpec.describe 'GET /api/articles', type: :request do
-  let!(:journalist1) { 2.times { create(:user, role: 'journalist') { :article1 } } }
-  let!(:journalist2) { 2.times { create(:user, role: 'journalist') { :article2 } } }
+  let(:journalist1) { create(:user, role: 'journalist') }
+  let!(:journalist2) { create(:user, role: 'journalist') }
+  let!(:article1) { create(:article, title: 'Second Article') }
+  let!(:article2) { create(:article, title: 'First Article') }
+  let!(:article3) { create(:article, title: 'Third Article') }
+  let!(:article4) { create(:article, title: 'Fourth Article') }
   let(:auth_headers) { journalist1.create_new_auth_token }
   let(:auth_headers) { journalist2.create_new_auth_token }
 

--- a/spec/requests/api/can_respond_with_list_of_articles_spec.rb
+++ b/spec/requests/api/can_respond_with_list_of_articles_spec.rb
@@ -41,8 +41,8 @@ RSpec.describe 'GET /api/articles', type: :request do
       get '/api/articles'
     end
 
-    it 'is expected to return 204 response status' do
-      expect(response).to have_http_status 204
+    it 'is expected to return 200 response status' do
+      expect(response).to have_http_status 200
     end
   end
 end

--- a/spec/requests/api/can_respond_with_list_of_articles_spec.rb
+++ b/spec/requests/api/can_respond_with_list_of_articles_spec.rb
@@ -44,5 +44,9 @@ RSpec.describe 'GET /api/articles', type: :request do
     it 'is expected to return 200 response status' do
       expect(response).to have_http_status 200
     end
+
+    it 'is expected to return an empty array' do
+      expect(response_json['articles']).to eq []
+    end
   end
 end

--- a/spec/requests/api/can_send_back_articles_based_on_category_spec.rb
+++ b/spec/requests/api/can_send_back_articles_based_on_category_spec.rb
@@ -22,12 +22,12 @@ RSpec.describe 'GET /api/articles/?category=Flat+Earth', type: :request do
       get '/api/articles/?category=Hollywood'
     end
 
-    it 'is expected to return status 404 ' do
-      expect(response).to have_http_status 404
+    it 'is expected to return status 200 ' do
+      expect(response).to have_http_status 200
     end
 
-    it 'is expected to return error message' do
-      expect(response_json['error_message']).to eq 'There is no Articles in this category'
+    it 'is expected to return an empty array' do
+      expect(response_json['articles']).to eq []
     end
   end
 end


### PR DESCRIPTION
Pt:https://www.pivotaltracker.com/story/show/178155092

### User Story
```
As an API
For the journalist to have an overview of their articles
I need to return all articles for that specific journalist
```
### Changes proposed in this pull request: 
-  sort by most recent
-  Journalist can see the articles
-  Seed three more articles
## What I have learned working on this feature:
- how to sort articles by most recent
- scape with `and return`