### PR TITLE
Opens up teaser attribute to the journalist CHORE

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -2,5 +2,5 @@ class Article < ApplicationRecord
   validates_presence_of :title, :teaser, :body, :category
   scope :most_recent, -> { order(created_at: :desc)}
   belongs_to :user
-  validates :category, inclusion: { in: ['Flat Earth', 'Aliens', 'Covid', 'Illuminati', 'Politics', 'Hollywood']}
+  validates :category, inclusion: { in: ['Science', 'Aliens', 'Covid', 'Illuminati', 'Politics', 'Hollywood']}
 end

--- a/app/serializers/articles_show_serializer.rb
+++ b/app/serializers/articles_show_serializer.rb
@@ -1,5 +1,5 @@
 class ArticlesShowSerializer < ActiveModel::Serializer
-  attributes :id, :title, :body, :date, :author, :category
+  attributes :id, :title, :teaser, :body, :date, :author, :category
 
   def author
     {

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -30,7 +30,7 @@ body = [
   The post links to an article on US website DC Dirty Laundry.'
 ]
 
-categories = ['Flat Earth', 'Aliens', 'Covid', 'Illuminati', 'Politics', 'Hollywood']
+categories = ['Science', 'Aliens', 'Covid', 'Illuminati', 'Politics', 'Hollywood']
 
 user = User.create(email: 'mrfake@fakenews.com', password: 'password', password_confirmation: 'password',
                    first_name: 'Mr.', last_name: 'Fake', role: 5)

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -4,6 +4,6 @@ FactoryBot.define do
     teaser { "some text" }
     body { "Husband found dead allegedly because he wasn't testing first" }
     association :user
-    category {"Flat Earth"}
+    category {"Science"}
   end
 end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Article, type: :model do
     it { is_expected.to validate_presence_of :body }
     it { is_expected.to validate_presence_of :category }
     it { is_expected.to validate_inclusion_of(:category).
-          in_array(['Flat Earth', 'Aliens', 'Covid', 'Illuminati', 'Politics', 'Hollywood'])}
+          in_array(['Science', 'Aliens', 'Covid', 'Illuminati', 'Politics', 'Hollywood'])}
   end
 
   describe 'Relationship between article and user' do

--- a/spec/requests/api/can_respond_with_list_of_articles_spec.rb
+++ b/spec/requests/api/can_respond_with_list_of_articles_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe 'GET /api/articles', type: :request do
     end
 
     it 'is expected to have a category' do
-      expect(response_json['articles'].first['category']).to eq 'Flat Earth'
+      expect(response_json['articles'].first['category']).to eq 'Science'
     end
   end
 

--- a/spec/requests/api/can_send_back_articles_based_on_category_spec.rb
+++ b/spec/requests/api/can_send_back_articles_based_on_category_spec.rb
@@ -1,9 +1,9 @@
-RSpec.describe 'GET /api/articles/?category=Flat+Earth', type: :request do
+RSpec.describe 'GET /api/articles/?category=Science', type: :request do
   let!(:article) { 2.times { create(:article) } }
   let!(:article2) { 2.times { create(:article, category: 'Aliens') } }
   describe 'successfully' do
     before do
-      get '/api/articles/?category=Flat+Earth'
+      get '/api/articles/?category=Science'
     end
     it 'is expected to return status 200' do
       expect(response).to have_http_status 200
@@ -14,7 +14,7 @@ RSpec.describe 'GET /api/articles/?category=Flat+Earth', type: :request do
     end
 
     it 'is expected to have the category that we ask for' do
-      expect(response_json['articles'].first['category']).to eq 'Flat Earth'
+      expect(response_json['articles'].first['category']).to eq 'Science'
     end
   end
   describe 'unsuccessfully with no articles of specified category' do

--- a/spec/requests/api/can_show_single_article_spec.rb
+++ b/spec/requests/api/can_show_single_article_spec.rb
@@ -13,6 +13,10 @@ RSpec.describe "GET /api/articles/:id" do
       expect(response_json["article"]["title"]).to eq "First title"
     end
 
+    it "is expected to return title" do
+      expect(response_json["article"]["teaser"]).to eq "some text"
+    end
+
     it "is expected to return body" do
       expect(response_json["article"]["body"]).to eq "Husband found dead allegedly because he wasn't testing first"
     end
@@ -30,7 +34,7 @@ RSpec.describe "GET /api/articles/:id" do
     end
 
     it 'is expected to show category' do
-      expect(response_json['article']['category']).to eq "Flat Earth"
+      expect(response_json['article']['category']).to eq "Science"
     end
   end
 


### PR DESCRIPTION
[**PT-Story:**  ](https://www.pivotaltracker.com/story/show/178171611)
### User Story 
``` 
As an API
In order for the journalist to view all details of their articles
I need to also send teaser with my show action
``` 
## Changes proposed in this pull request: 
* Adds :teaser attribute to show action 
* Changes Flat Earth category to Science