### PR TITLE
Api provides journalists to tag article as premium

### DIFF
--- a/app/controllers/api/articles_controller.rb
+++ b/app/controllers/api/articles_controller.rb
@@ -47,7 +47,7 @@ class Api::ArticlesController < ApplicationController
   end
 
   def article_params
-    params[:article].permit(:title, :teaser, :body, :category)
+    params[:article].permit(:title, :teaser, :body, :category, :premium)
   end
 
   def role_authenticator

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,5 +1,5 @@
 class Article < ApplicationRecord
-  validates_presence_of :title, :teaser, :body, :category
+  validates_presence_of :title, :teaser, :body, :category, :premium
   scope :most_recent, -> { order(updated_at: :desc) }
   belongs_to :user
   has_many :ratings

--- a/app/serializers/articles_index_serializer.rb
+++ b/app/serializers/articles_index_serializer.rb
@@ -1,5 +1,5 @@
 class ArticlesIndexSerializer < ActiveModel::Serializer
-  attributes :id, :title, :teaser, :date, :category, :image, :rating, :author
+  attributes :id, :title, :teaser, :date, :category, :image, :rating, :author, :premium
 
   def date
     object.updated_at.strftime('%F, %H:%M')

--- a/app/serializers/articles_show_serializer.rb
+++ b/app/serializers/articles_show_serializer.rb
@@ -1,5 +1,5 @@
 class ArticlesShowSerializer < ActiveModel::Serializer
-  attributes :id, :title, :teaser, :body, :date, :author, :category, :image, :rating, :author
+  attributes :id, :title, :teaser, :body, :date, :author, :category, :image, :rating, :author, :premium
 
   def author
     {

--- a/db/migrate/20210522132600_add_premium_to_article.rb
+++ b/db/migrate/20210522132600_add_premium_to_article.rb
@@ -1,0 +1,5 @@
+class AddPremiumToArticle < ActiveRecord::Migration[6.1]
+  def change
+    add_column :articles, :premium, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_19_195130) do
+ActiveRecord::Schema.define(version: 2021_05_22_132600) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -51,6 +51,7 @@ ActiveRecord::Schema.define(version: 2021_05_19_195130) do
     t.text "body"
     t.bigint "user_id"
     t.string "category"
+    t.boolean "premium"
     t.index ["user_id"], name: "index_articles_on_user_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -48,8 +48,7 @@ user = User.create(email: 'mrfake@fakenews.com', password: 'password', password_
                    first_name: 'Mr.', last_name: 'Fake', role: 5)
 
 (0...titles.count).each do |i|
- article = Article.create(title: titles[i], teaser: teasers[i], body: body[i], category: categories[rand(categories.count - 1)],
-                 user_id: user.id)
+ article = Article.create(title: titles[i], teaser: teasers[i], body: body[i], category: categories[rand(categories.count - 1)], user_id: user.id, premium: [true, false].sample)
   Rating.create(user_id: user.id, article_id: article.id, rating: 3 )
 end
 

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
     body { "Husband found dead allegedly because he wasn't testing first" }
     association :user
     category {"Science"}
+    premium { true }
     after(:build) do |article|
       file = File.open(Rails.root.join('spec', 'fixtures', 'fake-news-fixture.jpg'))
       article.image.attach(io: file, filename: 'article_image.jpg', content_type: 'image/jpg')

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Article, type: :model do
     it { is_expected.to have_db_column(:teaser).of_type(:text) }
     it { is_expected.to have_db_column(:body).of_type(:text) }
     it { is_expected.to have_db_column(:category).of_type(:string) }
+    it { is_expected.to have_db_column(:premium).of_type(:boolean) }
   end
 
   describe 'Validation' do
@@ -11,6 +12,7 @@ RSpec.describe Article, type: :model do
     it { is_expected.to validate_presence_of :teaser }
     it { is_expected.to validate_presence_of :body }
     it { is_expected.to validate_presence_of :category }
+    it { is_expected.to validate_presence_of :premium }
     it {
       is_expected.to validate_inclusion_of(:category)
         .in_array(%w[Science Aliens Covid Illuminati Politics Hollywood])

--- a/spec/requests/api/journalist/journalist_can_create_articles_spec.rb
+++ b/spec/requests/api/journalist/journalist_can_create_articles_spec.rb
@@ -14,7 +14,8 @@ RSpec.describe 'POST /api/articles', type: :request do
                teaser: 'Some damn teaser',
                body: "Husband found dead allegedly because he wasn't testing first",
                category: 'Hollywood',
-               image: image
+               image: image,
+               premium: true
              }
            },
            headers: auth_headers
@@ -49,7 +50,8 @@ RSpec.describe 'POST /api/articles', type: :request do
                title: 'Obnoxious Title',
                teaser: 'Some damn teaser',
                body: "Husband found dead allegedly because he wasn't testing first",
-               category: 'Hollywood'
+               category: 'Hollywood',
+               premium: true
              }
            },
            headers: auth_headers_member
@@ -77,7 +79,8 @@ RSpec.describe 'POST /api/articles', type: :request do
                title: 'Obnoxious Title',
                teaser: 'Some damn teaser',
                body: "Husband found dead allegedly because he wasn't testing first",
-               category: 'Hollywood'
+               category: 'Hollywood',
+               premium: true
              }
            },
            headers: { wrong_headers: 'wrong headers' }
@@ -100,7 +103,8 @@ RSpec.describe 'POST /api/articles', type: :request do
                title: '',
                teaser: 'Some damn teaser',
                body: "Husband found dead allegedly because he wasn't testing first",
-               category: 'Hollywood'
+               category: 'Hollywood',
+               premium: true
              }
            },
            headers: auth_headers

--- a/spec/requests/api/visitor/can_respond_with_list_of_articles_spec.rb
+++ b/spec/requests/api/visitor/can_respond_with_list_of_articles_spec.rb
@@ -34,6 +34,9 @@ RSpec.describe 'GET /api/articles', type: :request do
     it 'is expected to have a category' do
       expect(response_json['articles'].first['category']).to eq 'Science'
     end
+    it 'is expected to have a premium' do
+      expect(response_json['articles'].first['premium']).to eq true
+    end
   end
 
   describe 'unsuccessfully if no articles in database' do

--- a/spec/requests/api/visitor/can_show_single_article_spec.rb
+++ b/spec/requests/api/visitor/can_show_single_article_spec.rb
@@ -54,6 +54,10 @@ RSpec.describe 'GET /api/articles/:id' do
       expect(response_json['article']['category']).to eq 'Science'
     end
 
+    it 'is expected to show if it is premium' do
+      expect(response_json['article']['premium']).to eq true
+    end
+
     it 'is expected to show average rating' do
       expect(response_json['article']['rating']).to eq 3.5
     end


### PR DESCRIPTION
PT: https://www.pivotaltracker.com/story/show/178256265
### User Story
```
As a owner
To be able to monetize the app
I want some articles to be tagged as premium
```
### Changes Proposed
- adds premium attribute to Article
- refactors seed to include premium