### PR TITLE
[BUG] Premium 'false' breaks validation

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,5 +1,6 @@
 class Article < ApplicationRecord
-  validates_presence_of :title, :teaser, :body, :category, :premium
+  validates_presence_of :title, :teaser, :body, :category
+  validates_inclusion_of :premium, in: [false, true]
   scope :most_recent, -> { order(updated_at: :desc) }
   belongs_to :user
   has_many :ratings

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -42,18 +42,22 @@ image_url = [
   'https://image.cnbcfm.com/api/v1/image/106839139-16130497352021-02-11t023837z_615145576_rc22ql9gyycy_rtrmadp_0_health-coronavirus-usa.jpeg?v=1613049772&w=1600&h=900'
 ]
 
-categories = ['Science', 'Aliens', 'Covid', 'Illuminati', 'Politics', 'Hollywood']
+categories = %w[Science Aliens Covid Illuminati Politics Hollywood]
 
-user = User.create(email: 'mrfake@fakenews.com', password: 'password', password_confirmation: 'password',
-                   first_name: 'Mr.', last_name: 'Fake', role: 5)
+journalist = User.create(email: 'mrfake@fakenews.com', password: 'password', password_confirmation: 'password',
+                         first_name: 'Mr.', last_name: 'Fake', role: 5)
+
+subscriber = User.create(email: 'subscriber@gmail.com', password: 'password', password_confirmation: 'password',
+                         first_name: 'Bob', last_name: 'Kramer', role: 2)
 
 (0...titles.count).each do |i|
- article = Article.create(title: titles[i], teaser: teasers[i], body: body[i], category: categories[rand(categories.count - 1)], user_id: user.id, premium: [true, false].sample)
-  Rating.create(user_id: user.id, article_id: article.id, rating: 3 )
+  article = Article.create(title: titles[i], teaser: teasers[i], body: body[i],
+                           category: categories[rand(categories.count - 1)], user_id: user.id, premium: [true, false].sample)
+  Rating.create(user_id: journalist.id, article_id: article.id, rating: 3)
 end
 
 Article.all.each_with_index do |article, index|
   file = URI.open(image_url[index])
-  
+
   article.image.attach(io: file, filename: 'article_image.jpg', content_type: 'image/jpg')
 end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Article, type: :model do
     it { is_expected.to validate_presence_of :teaser }
     it { is_expected.to validate_presence_of :body }
     it { is_expected.to validate_presence_of :category }
-    it { is_expected.to validate_presence_of :premium }
+    it { is_expected.to validate_inclusion_of(:premium).in_array([false, true]) }
     it {
       is_expected.to validate_inclusion_of(:category)
         .in_array(%w[Science Aliens Covid Illuminati Politics Hollywood])


### PR DESCRIPTION
PT: https://www.pivotaltracker.com/story/show/178256736
## Description
Value of 'false' breaks validation of premium attribute. So it is less than 7 articles after seed, and it is impossible to create non-premium articles.
## Changes Proposed
- changes validate_presence_of to validates_inclusion_of for premium attribute
- adds subscriber to seed