### PR TITLE
Api provide visitors functionality to see specific Backyard Conspiracies

### DIFF
--- a/app/controllers/api/backyards_controller.rb
+++ b/app/controllers/api/backyards_controller.rb
@@ -7,7 +7,7 @@ class Api::BackyardsController < ApplicationController
 
   def show
      backyard_article = Article.find(params[:id])
-    render json: backyard_article, serializer: BackyardsShowSerializerSerializer, root: :backyard_articles
+    render json: backyard_article, serializer: BackyardsShowSerializerSerializer, root: :backyard_article
   end
   
 

--- a/app/controllers/api/backyards_controller.rb
+++ b/app/controllers/api/backyards_controller.rb
@@ -5,6 +5,12 @@ class Api::BackyardsController < ApplicationController
     render json: backyard_articles, each_serializer: BackyardsIndexSerializer, root: :backyard_articles
   end
 
+  def show
+     backyard_article = Article.find(params[:id])
+    render json: backyard_article, serializer: BackyardsShowSerializerSerializer, root: :backyard_articles
+  end
+  
+
   private
 
   def get_country

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,13 +1,13 @@
 class Article < ApplicationRecord
   validates_inclusion_of :backyard, in: [false, true]
-  validates_presence_of :title
+  validates_presence_of :title,:body
   belongs_to :user
 
   scope :most_recent, -> { order(updated_at: :desc) }
   scope :public_articles, -> { where(backyard: false) }
 
   # Normal articles
-  validates :category, :body, :teaser, presence: true, unless: :is_backyard?
+  validates :category,  :teaser, presence: true, unless: :is_backyard?
   validates :premium, inclusion: { in: [false, true] }, unless: :is_backyard?
   validates :category, inclusion: { in: %w[Science Aliens Covid Illuminati Politics Hollywood] }, unless: :is_backyard?
   has_one_attached :image

--- a/app/serializers/backyards_index_serializer.rb
+++ b/app/serializers/backyards_index_serializer.rb
@@ -1,5 +1,5 @@
 class BackyardsIndexSerializer < ActiveModel::Serializer
-  attributes :id, :title, :theme, :date, :written_by, :location
+  attributes :id, :title,:theme, :date, :written_by, :location
 
   def date
     object.updated_at.strftime('%F, %H:%M')

--- a/app/serializers/backyards_show_serializer_serializer.rb
+++ b/app/serializers/backyards_show_serializer_serializer.rb
@@ -1,0 +1,11 @@
+class BackyardsShowSerializerSerializer < ActiveModel::Serializer
+  attributes :id, :title, :body, :theme, :date, :written_by, :location
+
+  def date
+    object.updated_at.strftime('%F, %H:%M')
+  end
+
+  def written_by
+    "#{object.user.first_name} #{object.user.last_name}"
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,6 @@ Rails.application.routes.draw do
   namespace :api do
     resources :ratings, only: [:create]
     resources :articles, only: [:index, :show, :create, :update]
-    resources :backyards, only: [:index]
+    resources :backyards, only: [:index, :show]
   end
 end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -13,11 +13,11 @@ RSpec.describe Article, type: :model do
   describe 'Validation' do
     it { is_expected.to validate_presence_of :title }
     it { is_expected.to validate_inclusion_of(:backyard).in_array([false, true]) }
+    it { is_expected.to validate_presence_of :body }
 
     context 'Normal article' do
       before { allow(subject).to receive(:is_backyard?).and_return(false) }
 
-      it { is_expected.to validate_presence_of :body }
       it { is_expected.to validate_presence_of :teaser }
       it { is_expected.to validate_presence_of :category }
       it { is_expected.to validate_inclusion_of(:premium).in_array([false, true]) }

--- a/spec/requests/api/visitor/can_respond_with_a_single_backyard_article_spec.rb
+++ b/spec/requests/api/visitor/can_respond_with_a_single_backyard_article_spec.rb
@@ -1,0 +1,24 @@
+RSpec.describe 'GET api/backyards/:id', type: :request do
+  let!(:backyard_article) { create(:backyard_article) }
+
+  describe 'successfully' do
+    before do
+      get "/api/backyards/#{backyard_article.id}"
+    end
+
+    it "is expected to return 200 status" do
+      expect(response).to have_http_status 200  
+    end
+
+    it "is expected to have title" do
+      expect(response_json['backyard_articles']['title']).to eq 'My cat is really spying on me' 
+    end
+    
+    it "is expected to have a body" do
+      expect(response_json['backyard_articles']['body']).to eq 'My cat was flying yesterday'  
+      
+    end
+    
+    
+  end
+end

--- a/spec/requests/api/visitor/can_respond_with_a_single_backyard_article_spec.rb
+++ b/spec/requests/api/visitor/can_respond_with_a_single_backyard_article_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe 'GET api/backyards/:id', type: :request do
+RSpec.describe 'GET /api/backyards/:id', type: :request do
   let!(:backyard_article) { create(:backyard_article) }
 
   describe 'successfully' do
@@ -6,19 +6,41 @@ RSpec.describe 'GET api/backyards/:id', type: :request do
       get "/api/backyards/#{backyard_article.id}"
     end
 
-    it "is expected to return 200 status" do
-      expect(response).to have_http_status 200  
+    it 'is expected to return 200 status' do
+      expect(response).to have_http_status 200
     end
 
-    it "is expected to have title" do
-      expect(response_json['backyard_articles']['title']).to eq 'My cat is really spying on me' 
+    it 'is expected to have title' do
+      expect(response_json['backyard_article']['title']).to eq 'My cat is really spying on me'
     end
-    
-    it "is expected to have a body" do
-      expect(response_json['backyard_articles']['body']).to eq 'My cat was flying yesterday'  
-      
+
+    it 'is expected to have a body' do
+      expect(response_json['backyard_article']['body']).to eq 'My cat was flying yesterday'
     end
-    
-    
+
+    it 'is expected to include written by Mr. fake' do
+      expect(response_json['backyard_article']['written_by']).to eq 'Mr. Fake'
+    end
+
+    it 'is expected to show category' do
+      expect(response_json['backyard_article']['theme']).to eq 'Haunted animals'
+    end
+
+    it 'is expected to have country of the backyard article' do
+      expect(response_json['backyard_article']['location']).to eq 'Sweden'
+    end
+  end
+
+  describe 'unsuccessfully' do
+    before do
+      get '/api/backyards/123'
+    end
+
+    it 'is expected to return 404 status' do
+      expect(response).to have_http_status 404
+    end
+    it 'is expected to have error message' do
+      expect(response_json['error_message']).to eq "Couldn't find Article with 'id'=123"
+    end
   end
 end


### PR DESCRIPTION
PT:  https://www.pivotaltracker.com/story/show/178259329
### User Story:
```
As an API
In order to provide the client with data to show a specific backyard article
I need an endpoint for show requests
```
____________
### Changes Proposed
- Adds endpoint  for specific backyard article  
- Sad path for backyard specific article
_____________

### What we Learned
- how to use root for changing the key name 
