### PR TITLE
API Body into array refactor (CHORE)

### DIFF
--- a/app/controllers/api/articles_controller.rb
+++ b/app/controllers/api/articles_controller.rb
@@ -47,7 +47,7 @@ class Api::ArticlesController < ApplicationController
   end
 
   def article_params
-    params[:article].permit(:title, :teaser, :body, :category, :premium)
+    params[:article].permit(:title, :teaser, :category, :premium, body: [])
   end
 
   def role_authenticator

--- a/db/migrate/20210524123047_changes_body_type_to_array.rb
+++ b/db/migrate/20210524123047_changes_body_type_to_array.rb
@@ -1,0 +1,5 @@
+class ChangesBodyTypeToArray < ActiveRecord::Migration[6.1]
+  def change
+    change_column :articles, :body, :text, array: true, using: 'body::text[]'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_23_174401) do
+ActiveRecord::Schema.define(version: 2021_05_24_123047) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -48,7 +48,7 @@ ActiveRecord::Schema.define(version: 2021_05_23_174401) do
     t.text "teaser"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.text "body"
+    t.text "body", array: true
     t.bigint "user_id"
     t.string "category"
     t.boolean "premium", default: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -70,6 +70,6 @@ end
 
 puts 'Creating backyard articles...'
 (0...titles.count).each do |i|
-  backyard_article = Article.create(title: titles[i], backyard: true, location: ['Sweden','Denmark'].sample,
+  backyard_article = Article.create(title: titles[i], body: body[i], backyard: true, location: ['Sweden','Denmark'].sample,
                                     theme: themes[i], user_id: subscriber.id)
 end

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :article do
     title { 'First title' }
     teaser { 'some text' }
-    body { "Husband found dead allegedly because he wasn't testing first" }
+    body { ["Husband found dead allegedly because he wasn't testing first", 'Wife devastated.' ] }
     association :user
     backyard { false }
     category { 'Science' }
@@ -15,7 +15,7 @@ FactoryBot.define do
   
   factory :backyard_article, class: Article do
     title { 'My cat is really spying on me' }
-    body { 'My cat was flying yesterday' }
+    body { ['My cat was flying yesterday', 'Really a surreal experience' ] }
     theme { 'Haunted animals' }
     association :user
     backyard { true }

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -8,12 +8,15 @@ RSpec.describe Article, type: :model do
     it { is_expected.to have_db_column(:theme).of_type(:string) }
     it { is_expected.to have_db_column(:backyard).of_type(:boolean) }
     it { is_expected.to have_db_column(:premium).of_type(:boolean) }
+    it 'is expected to have a body of text in an array' do
+      expect(subject[:body]).kind_of?(Array)
+    end
   end
 
   describe 'Validation' do
     it { is_expected.to validate_presence_of :title }
-    it { is_expected.to validate_inclusion_of(:backyard).in_array([false, true]) }
     it { is_expected.to validate_presence_of :body }
+    it { is_expected.to validate_inclusion_of(:backyard).in_array([false, true]) }
 
     context 'Normal article' do
       before { allow(subject).to receive(:is_backyard?).and_return(false) }

--- a/spec/requests/api/journalist/journalist_can_create_articles_spec.rb
+++ b/spec/requests/api/journalist/journalist_can_create_articles_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'POST /api/articles', type: :request do
              article: {
                title: 'Obnoxious Title',
                teaser: 'Some damn teaser',
-               body: "Husband found dead allegedly because he wasn't testing first",
+               body: ["Husband found dead allegedly because he wasn't testing first"],
                category: 'Hollywood',
                image: image,
                premium: true
@@ -49,7 +49,7 @@ RSpec.describe 'POST /api/articles', type: :request do
              article: {
                title: 'Obnoxious Title',
                teaser: 'Some damn teaser',
-               body: "Husband found dead allegedly because he wasn't testing first",
+               body: ["Husband found dead allegedly because he wasn't testing first"],
                category: 'Hollywood',
                premium: true
              }
@@ -78,7 +78,7 @@ RSpec.describe 'POST /api/articles', type: :request do
              article: {
                title: 'Obnoxious Title',
                teaser: 'Some damn teaser',
-               body: "Husband found dead allegedly because he wasn't testing first",
+               body: ["Husband found dead allegedly because he wasn't testing first"],
                category: 'Hollywood',
                premium: true
              }
@@ -102,7 +102,7 @@ RSpec.describe 'POST /api/articles', type: :request do
              article: {
                title: '',
                teaser: 'Some damn teaser',
-               body: "Husband found dead allegedly because he wasn't testing first",
+               body: ["Husband found dead allegedly because he wasn't testing first"],
                category: 'Hollywood',
                premium: true
              }

--- a/spec/requests/api/journalist/journalist_can_edit_their_own_article_spec.rb
+++ b/spec/requests/api/journalist/journalist_can_edit_their_own_article_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'PUT /api/articles/:id', type: :request do
             article: {
               title: 'New Article',
               teaser: 'Some damn teaser',
-              body: "Husband found dead allegedly because he wasn't testing first or was he?!?!",
+              body: ["Husband found dead allegedly because he wasn't testing first or was he?!?!"],
               category: 'Hollywood'
             }
           },
@@ -39,7 +39,7 @@ RSpec.describe 'PUT /api/articles/:id', type: :request do
     end
 
     it 'is expected to have new body' do
-      expect(updated_article['body']).to eq 'Husband found dead allegedly because he wasn\'t testing first or was he?!?!'
+      expect(updated_article['body'].first).to eq 'Husband found dead allegedly because he wasn\'t testing first or was he?!?!'
     end
 
     it 'is expected to have new category' do
@@ -54,7 +54,7 @@ RSpec.describe 'PUT /api/articles/:id', type: :request do
             article: {
               title: 'New Article',
               teaser: 'Some damn teaser',
-              body: "Husband found dead allegedly because he wasn't testing first or was he?!?!",
+              body: ["Husband found dead allegedly because he wasn't testing first or was he?!?!"],
               category: 'Hollywood'
             }
           },

--- a/spec/requests/api/visitor/can_respond_with_a_single_backyard_article_spec.rb
+++ b/spec/requests/api/visitor/can_respond_with_a_single_backyard_article_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'GET /api/backyards/:id', type: :request do
     end
 
     it 'is expected to have a body' do
-      expect(response_json['backyard_article']['body']).to eq 'My cat was flying yesterday'
+      expect(response_json['backyard_article']['body'].first).to eq 'My cat was flying yesterday'
     end
 
     it 'is expected to include written by Mr. fake' do

--- a/spec/requests/api/visitor/can_show_single_article_spec.rb
+++ b/spec/requests/api/visitor/can_show_single_article_spec.rb
@@ -30,12 +30,12 @@ RSpec.describe 'GET /api/articles/:id' do
       expect(response_json['article']['title']).to eq 'First title'
     end
 
-    it 'is expected to return title' do
+    it 'is expected to return teaser' do
       expect(response_json['article']['teaser']).to eq 'some text'
     end
 
     it 'is expected to return body' do
-      expect(response_json['article']['body']).to eq "Husband found dead allegedly because he wasn't testing first"
+      expect(response_json['article']['body'].first).to eq "Husband found dead allegedly because he wasn't testing first"
     end
 
     it 'is expected to return date' do


### PR DESCRIPTION
[PT Story](https://www.pivotaltracker.com/story/show/178263624)

```
As an API
In order to better provide the client with divisible pieces of text
I want to store `body` as chunks of text in an array"
```

## Changes proposed
- Turns body attribute into an array of texts
- Validates new functionality
- Revises tests to work with this
- Revises create and update action to work with this