### PR TITLE
Api provides only Editor permission to publish articles

### DIFF
--- a/app/controllers/api/articles_controller.rb
+++ b/app/controllers/api/articles_controller.rb
@@ -32,14 +32,16 @@ class Api::ArticlesController < ApplicationController
 
   def update
     article = Article.find(params[:id])
-    updated_article = article.update(article_params)
-    
-    binding.pry
-    
-    if updated_article
+    if params[:published]
+      article['published'] = true
       render json: { message: 'Your article has been successfully updated!' }, status: 200
     else
-      render json: { message: 'Article has not been updated' }, status: 422
+      updated_article = article.update(article_params)
+      if updated_article
+        render json: { message: 'Your article has been successfully updated!' }, status: 200
+      else
+        render json: { message: 'Article has not been updated' }, status: 422
+      end
     end
   end
 

--- a/app/controllers/api/articles_controller.rb
+++ b/app/controllers/api/articles_controller.rb
@@ -32,9 +32,13 @@ class Api::ArticlesController < ApplicationController
 
   def update
     article = Article.find(params[:id])
-    if params[:published]
+    if current_user&.editor? 
+      if params[:published] 
       article['published'] = true
       render json: { message: 'Your article has been successfully updated!' }, status: 200
+      end 
+    else 
+  
     else
       updated_article = article.update(article_params)
       if updated_article
@@ -43,6 +47,7 @@ class Api::ArticlesController < ApplicationController
         render json: { message: 'Article has not been updated' }, status: 422
       end
     end
+  end
   end
 
   private

--- a/app/controllers/api/articles_controller.rb
+++ b/app/controllers/api/articles_controller.rb
@@ -33,6 +33,9 @@ class Api::ArticlesController < ApplicationController
   def update
     article = Article.find(params[:id])
     updated_article = article.update(article_params)
+    
+    binding.pry
+    
     if updated_article
       render json: { message: 'Your article has been successfully updated!' }, status: 200
     else

--- a/app/controllers/api/articles_controller.rb
+++ b/app/controllers/api/articles_controller.rb
@@ -32,13 +32,14 @@ class Api::ArticlesController < ApplicationController
 
   def update
     article = Article.find(params[:id])
-    if current_user&.editor? 
-      if params[:published] 
-      article['published'] = true
-      render json: { message: 'Your article has been successfully updated!' }, status: 200
-      end 
-    else 
-  
+    if params[:published]
+      if current_user&.editor?
+        article.update(published: true)
+        render json: { message: 'Your article has been successfully updated!' }, status: 200
+      else
+        render json: { error_message: 'You are not authorized to publish an article!' }, status: 403
+      end
+
     else
       updated_article = article.update(article_params)
       if updated_article
@@ -47,7 +48,6 @@ class Api::ArticlesController < ApplicationController
         render json: { message: 'Article has not been updated' }, status: 422
       end
     end
-  end
   end
 
   private

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -9,6 +9,7 @@ class Article < ApplicationRecord
   # Normal articles
   validates :category,:teaser, presence: true, unless: :is_backyard?
   validates :premium, inclusion: { in: [false, true] }, unless: :is_backyard?
+  validates :published, inclusion: { in: [false, true] }, unless: :is_backyard?
   validates :category, inclusion: { in: %w[Science Aliens Covid Illuminati Politics Hollywood] }, unless: :is_backyard?
   has_one_attached :image
   has_many :ratings

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -7,7 +7,7 @@ class Article < ApplicationRecord
   scope :public_articles, -> { where(backyard: false) }
 
   # Normal articles
-  validates :category,  :teaser, presence: true, unless: :is_backyard?
+  validates :category,:teaser, presence: true, unless: :is_backyard?
   validates :premium, inclusion: { in: [false, true] }, unless: :is_backyard?
   validates :category, inclusion: { in: %w[Science Aliens Covid Illuminati Politics Hollywood] }, unless: :is_backyard?
   has_one_attached :image

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,7 +6,7 @@ class User < ActiveRecord::Base
          :recoverable, :rememberable, :validatable
   include DeviseTokenAuth::Concerns::User
 
-  enum role: { member: 1, subscriber: 2, journalist: 5 }
+  enum role: { member: 1, subscriber: 2, journalist: 5, editor: 10 }
 
   has_many :articles
   has_many :ratings

--- a/db/migrate/20210524194436_add_published_to_articles.rb
+++ b/db/migrate/20210524194436_add_published_to_articles.rb
@@ -1,0 +1,5 @@
+class AddPublishedToArticles < ActiveRecord::Migration[6.1]
+  def change
+    add_column :articles, :published, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_24_123047) do
+ActiveRecord::Schema.define(version: 2021_05_24_194436) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -55,6 +55,7 @@ ActiveRecord::Schema.define(version: 2021_05_24_123047) do
     t.string "location"
     t.string "theme"
     t.boolean "backyard", default: false
+    t.boolean "published", default: false
     t.index ["user_id"], name: "index_articles_on_user_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -54,6 +54,10 @@ puts 'Creating subscriber...'
 subscriber = User.create(email: 'subscriber@gmail.com', password: 'password', password_confirmation: 'password',
                          first_name: 'Bob', last_name: 'Kramer', role: 2)
 
+puts 'Creating editor....'
+editor = User.create(email: 'editor@gmail.com', password: 'password', password_confirmation: 'password',
+                     first_name: 'Sam', last_name: 'Kramer', role: 10)
+
 puts 'Creating articles...'
 (0...titles.count).each do |i|
   article = Article.create(title: titles[i], teaser: teasers[i], body: body[i],

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -2,20 +2,21 @@ FactoryBot.define do
   factory :article do
     title { 'First title' }
     teaser { 'some text' }
-    body { ["Husband found dead allegedly because he wasn't testing first", 'Wife devastated.' ] }
+    body { ["Husband found dead allegedly because he wasn't testing first", 'Wife devastated.'] }
     association :user
     backyard { false }
     category { 'Science' }
     premium { true }
+    published { true }
     after(:build) do |article|
       file = File.open(Rails.root.join('spec', 'fixtures', 'fake-news-fixture.jpg'))
       article.image.attach(io: file, filename: 'article_image.jpg', content_type: 'image/jpg')
     end
   end
-  
+
   factory :backyard_article, class: Article do
     title { 'My cat is really spying on me' }
-    body { ['My cat was flying yesterday', 'Really a surreal experience' ] }
+    body { ['My cat was flying yesterday', 'Really a surreal experience'] }
     theme { 'Haunted animals' }
     association :user
     backyard { true }

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     backyard { false }
     category { 'Science' }
     premium { true }
-    published { true }
+    published { false }
     after(:build) do |article|
       file = File.open(Rails.root.join('spec', 'fixtures', 'fake-news-fixture.jpg'))
       article.image.attach(io: file, filename: 'article_image.jpg', content_type: 'image/jpg')

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -4,8 +4,8 @@ FactoryBot.define do
   factory :user do
     email { Faker::Internet.email }
     password { 'password' }
-    first_name { "Mr." }
-    last_name { "Fake" }
+    first_name { 'Mr.' }
+    last_name { 'Fake' }
     role { 5 }
   end
 end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Article, type: :model do
     it { is_expected.to have_db_column(:theme).of_type(:string) }
     it { is_expected.to have_db_column(:backyard).of_type(:boolean) }
     it { is_expected.to have_db_column(:premium).of_type(:boolean) }
+    it { is_expected.to have_db_column(:published).of_type(:boolean) }
     it 'is expected to have a body of text in an array' do
       expect(subject[:body]).kind_of?(Array)
     end
@@ -28,6 +29,7 @@ RSpec.describe Article, type: :model do
         is_expected.to validate_inclusion_of(:category)
           .in_array(%w[Science Aliens Covid Illuminati Politics Hollywood])
       }
+      it { is_expected.to validate_inclusion_of(:published).in_array([false, true])}
     end
 
     context 'Backyard article' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe User, type: :model do
   end
 
   describe 'role' do
-    it { is_expected.to define_enum_for(:role).with_values({ member: 1, subscriber: 2, journalist: 5 }) }
+    it { is_expected.to define_enum_for(:role).with_values({ member: 1, subscriber: 2, journalist: 5, editor: 10 }) }
   end
 
   describe 'Relationship between article and user' do

--- a/spec/requests/api/editor/editor_can_publish_articles_spec.rb
+++ b/spec/requests/api/editor/editor_can_publish_articles_spec.rb
@@ -8,15 +8,8 @@ RSpec.describe 'PUT api/articles', type: :request do
   describe 'successfully' do
     before do
       put "/api/articles/#{article.id}",
-          params: {
-            article: {
-              title: 'Obnoxious Title',
-              teaser: 'Some damn teaser',
-              body: ["Husband found dead allegedly because he wasn't testing first"],
-              category: 'Hollywood',
-              premium: true,
+          params: { 
               published: true
-            }
           },
           headers: auth_headers
     end
@@ -26,7 +19,7 @@ RSpec.describe 'PUT api/articles', type: :request do
     end
 
     it 'is expected to return a success message' do
-      expect(response_json['message']).to eq 'Your article has been successfully been updated!'
+      expect(response_json['message']).to eq 'Your article has been successfully updated!'
     end
   end
 end

--- a/spec/requests/api/editor/editor_can_publish_articles_spec.rb
+++ b/spec/requests/api/editor/editor_can_publish_articles_spec.rb
@@ -1,0 +1,32 @@
+RSpec.describe 'PUT api/articles', type: :request do
+  let!(:editor) { create(:user, role: 'editor') }
+  let!(:journalist) { create(:user, role: 'journalist') }
+  let!(:article) { create(:article, title: 'Old Article', user_id: journalist.id, published: false) }
+  let!(:auth_headers) { editor.create_new_auth_token }
+
+
+  describe 'successfully' do
+    before do
+      put "/api/articles/#{article.id}",
+          params: {
+            article: {
+              title: 'Obnoxious Title',
+              teaser: 'Some damn teaser',
+              body: ["Husband found dead allegedly because he wasn't testing first"],
+              category: 'Hollywood',
+              premium: true,
+              published: true
+            }
+          },
+          headers: auth_headers
+    end
+
+    it 'is expected to return a 200 status' do
+      expect(response).to have_http_status 200
+    end
+
+    it 'is expected to return a success message' do
+      expect(response_json['message']).to eq 'Your article has been successfully been updated!'
+    end
+  end
+end

--- a/spec/requests/api/editor/editor_can_publish_articles_spec.rb
+++ b/spec/requests/api/editor/editor_can_publish_articles_spec.rb
@@ -3,6 +3,7 @@ RSpec.describe 'PUT api/articles', type: :request do
   let!(:journalist) { create(:user, role: 'journalist') }
   let!(:article) { create(:article, title: 'Old Article', user_id: journalist.id, published: false) }
   let!(:auth_headers) { editor.create_new_auth_token }
+  let!(:auth_headers_journalist) { journalist.create_new_auth_token }
 
 
   describe 'successfully' do
@@ -20,6 +21,23 @@ RSpec.describe 'PUT api/articles', type: :request do
 
     it 'is expected to return a success message' do
       expect(response_json['message']).to eq 'Your article has been successfully updated!'
+    end
+  end
+  describe 'unsuccessfully' do
+    before do
+      put "/api/articles/#{article.id}",
+          params: { 
+              published: true
+          },
+          headers: auth_headers_journalist
+    end
+
+    it 'is expected to return a 401 status' do
+      expect(response).to have_http_status 401
+    end
+
+    it 'is expected to return a error message' do
+      expect(response_json['error_message']).to eq 'You are not authorized to publish an article!'
     end
   end
 end

--- a/spec/requests/api/editor/editor_can_publish_articles_spec.rb
+++ b/spec/requests/api/editor/editor_can_publish_articles_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'PUT api/articles', type: :request do
   let!(:auth_headers_journalist) { journalist.create_new_auth_token }
 
 
-  describe 'successfully' do
+  describe 'successfully as an editor' do
     before do
       put "/api/articles/#{article.id}",
           params: { 
@@ -22,8 +22,14 @@ RSpec.describe 'PUT api/articles', type: :request do
     it 'is expected to return a success message' do
       expect(response_json['message']).to eq 'Your article has been successfully updated!'
     end
+
+    it "is expected to set published status to true" do
+      expect(article.reload.published?).to eq true
+      
+    end
+    
   end
-  describe 'unsuccessfully' do
+  describe 'unsuccessfully as a journalist' do
     before do
       put "/api/articles/#{article.id}",
           params: { 
@@ -32,8 +38,8 @@ RSpec.describe 'PUT api/articles', type: :request do
           headers: auth_headers_journalist
     end
 
-    it 'is expected to return a 401 status' do
-      expect(response).to have_http_status 401
+    it 'is expected to return a 403 status' do
+      expect(response).to have_http_status 403
     end
 
     it 'is expected to return a error message' do


### PR DESCRIPTION
**PT-Story:**  https://www.pivotaltracker.com/story/show/178264656
### User Story 
``` 
As an Api
To maintain a high standard of service
we need to provide a method for only editors to publish articles
``` 
## Changes proposed in this pull request: 
* New role EDITOR  to USER in ENUM
* Add `published` boolean to Article migration to ARTICLE
* Sad path that journalist CANNOT publish
## What I have learned working on this feature: 
*   How to give permission to different roles 