### PR TITLE
Api only responds with published articles to client

### DIFF
--- a/app/controllers/api/articles_controller.rb
+++ b/app/controllers/api/articles_controller.rb
@@ -18,7 +18,11 @@ class Api::ArticlesController < ApplicationController
 
   def show
     article = Article.find(params[:id])
-    render json: article, serializer: ArticlesShowSerializer
+    if article.published?
+      render json: article, serializer: ArticlesShowSerializer
+    else
+      render json: { error_message: 'This article does not exist' }, status: 404
+    end
   end
 
   def create

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -4,7 +4,7 @@ class Article < ApplicationRecord
   belongs_to :user
 
   scope :most_recent, -> { order(updated_at: :desc) }
-  scope :public_articles, -> { where(backyard: false) }
+  scope :public_articles, -> { where(backyard: false, published: true) }
 
   # Normal articles
   validates :category,:teaser, presence: true, unless: :is_backyard?

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -57,7 +57,7 @@ subscriber = User.create(email: 'subscriber@gmail.com', password: 'password', pa
 puts 'Creating articles...'
 (0...titles.count).each do |i|
   article = Article.create(title: titles[i], teaser: teasers[i], body: body[i],
-                           category: categories[rand(categories.count - 1)], user_id: journalist.id, premium: [true, false].sample)
+                           category: categories[rand(categories.count - 1)], user_id: journalist.id, premium: [true, false].sample, published: true)
   Rating.create(user_id: journalist.id, article_id: article.id, rating: 3)
 end
 

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     backyard { false }
     category { 'Science' }
     premium { true }
-    published { false }
+    published { true }
     after(:build) do |article|
       file = File.open(Rails.root.join('spec', 'fixtures', 'fake-news-fixture.jpg'))
       article.image.attach(io: file, filename: 'article_image.jpg', content_type: 'image/jpg')

--- a/spec/requests/api/editor/editor_can_publish_articles_spec.rb
+++ b/spec/requests/api/editor/editor_can_publish_articles_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe 'PUT api/articles', type: :request do
   let!(:article) { create(:article, title: 'Old Article', user_id: journalist.id, published: false) }
   let!(:auth_headers) { editor.create_new_auth_token }
 
-
   describe 'successfully' do
     before do
       put "/api/articles/#{article.id}",

--- a/spec/requests/api/editor/editor_can_publish_articles_spec.rb
+++ b/spec/requests/api/editor/editor_can_publish_articles_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'PUT api/articles', type: :request do
       expect(response_json['message']).to eq 'Your article has been successfully updated!'
     end
 
-    it "is expected to set published status to true" do
+    it 'is expected to set published status to true' do
       expect(article.reload.published?).to eq true
     end
   end

--- a/spec/requests/api/visitor/can_respond_with_list_of_articles_spec.rb
+++ b/spec/requests/api/visitor/can_respond_with_list_of_articles_spec.rb
@@ -3,6 +3,8 @@ RSpec.describe 'GET /api/articles', type: :request do
     let!(:article1) { create(:article, title: 'Second Article', created_at: Time.zone.now - 100_000) }
     let!(:article2) { create(:article, title: 'First Article', created_at: Time.zone.now - 200_000) }
     let!(:article3) { create(:article, title: 'Third Article') }
+    let!(:unpublished_articles) { 2.times { create(:article, published: false) } }
+
     before do
       get '/api/articles'
     end
@@ -11,7 +13,7 @@ RSpec.describe 'GET /api/articles', type: :request do
       expect(response).to have_http_status 200
     end
 
-    it 'is expected to have lenght of 3 articles' do
+    it 'is expected to only respond with the 3 published articles' do
       expect(response_json['articles'].count).to eq 3
     end
 

--- a/spec/requests/api/visitor/can_show_single_article_spec.rb
+++ b/spec/requests/api/visitor/can_show_single_article_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe 'GET /api/articles/:id' do
     end
 
     it 'is expected to have error message' do
-      expect(response_json['error_message']).to eq "Couldn't find Article with 'id'=123"
+      expect(response_json['error_message']).to eq "This article does not exist"
     end
   end
 end

--- a/spec/requests/api/visitor/can_show_single_article_spec.rb
+++ b/spec/requests/api/visitor/can_show_single_article_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe 'GET /api/articles/:id' do
   let!(:subscriber2) { create(:user, role: 'subscriber') }
   let(:auth_headers2) { subscriber2.create_new_auth_token }
   let!(:article) { create(:article) }
+  let!(:unpublished_article) { create(:article, published: false) }
 
   describe 'successfully' do
     before do
@@ -66,6 +67,20 @@ RSpec.describe 'GET /api/articles/:id' do
   describe 'unsuccessfully with no article' do
     before do
       get '/api/articles/123'
+    end
+
+    it 'is expected to response with status 404' do
+      expect(response).to have_http_status 404
+    end
+
+    it 'is expected to have error message' do
+      expect(response_json['error_message']).to eq "Couldn't find Article with 'id'=123"
+    end
+  end
+
+  describe 'unsuccessfully if the article is unpublished' do
+    before do
+      get "/api/articles/#{unpublished_article.id}"
     end
 
     it 'is expected to response with status 404' do


### PR DESCRIPTION
[**PT-Story:**  ](https://www.pivotaltracker.com/story/show/178274983)
### User Story 
``` 
As an API
In order to not display unpublished articles
I need to filter the response to only include published articles
``` 
## Changes proposed in this pull request: 
* Restricts index action to only show published articles
* Seeds articles with published attribute
