### PR TITLE
Api provides functionality for Editors to delete backyard articles

### DIFF
--- a/app/controllers/api/backyards_controller.rb
+++ b/app/controllers/api/backyards_controller.rb
@@ -1,5 +1,6 @@
 class Api::BackyardsController < ApplicationController
   before_action :authenticate_user!, only: %i[create]
+  before_action :editor_authenticator, only: %i[destroy]
 
   def index
     country = get_country
@@ -22,6 +23,12 @@ class Api::BackyardsController < ApplicationController
     end
   end
 
+  def destroy
+    article = Article.find(params[:id])
+    article.destroy
+    render json: { message: 'The article was successfully deleted' }
+  end
+
   private
 
   def get_country
@@ -38,5 +45,11 @@ class Api::BackyardsController < ApplicationController
     backyard_article['backyard'] = true
     backyard_article.save
     backyard_article
+  end
+
+  def editor_authenticator
+    return if current_user.editor?
+
+    render json: { error_message: 'You are not authorized to delete this article' }, status: 403
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
   namespace :api do
     resources :ratings, only: [:create]
     resources :articles, only: %i[index show create update destroy]
-    resources :backyards, only: %i[index show create, destroy]
+    resources :backyards, only: %i[index show create destroy]
     resources :statistics, only: [:index]
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
   namespace :api do
     resources :ratings, only: [:create]
     resources :articles, only: %i[index show create update destroy]
-    resources :backyards, only: %i[index show create]
+    resources :backyards, only: %i[index show create, destroy]
     resources :statistics, only: [:index]
   end
 end

--- a/spec/requests/api/editor/editor_can_delete_backyard_articles_spec.rb
+++ b/spec/requests/api/editor/editor_can_delete_backyard_articles_spec.rb
@@ -1,0 +1,54 @@
+RSpec.describe 'DELETE /api/articles/:id' do
+  let(:article) { create(:backyard_article) }
+  let(:editor) { create(:user, role: 'editor') }
+  let(:editor_headers) { editor.create_new_auth_token }
+
+  describe 'Successfully' do
+    before do
+      delete "/api/backyards/#{article.id}", headers: editor_headers
+    end
+
+    it 'is expected to return status code 200' do
+      expect(response).to have_http_status 200
+    end
+
+    it 'is expected to return a success message' do
+      expect(response_json['message']).to eq 'The article was successfully deleted'
+    end
+
+    it 'is expected to have deleted article' do
+      expect(Article.all.count).to eq 0
+    end
+  end
+
+  describe 'Unsuccessfully because article does not exist' do
+    before do
+      delete '/api/backyards/1337', headers: editor_headers
+    end
+
+    it 'is expected to return status code 404' do
+      expect(response).to have_http_status 404
+    end
+
+    it 'is expected to return an error message' do
+      expect(response_json['error_message']).to eq "Couldn't find Article with 'id'=1337"
+    end
+  end
+
+  describe 'Unsuccessfully as a journalist' do
+    let(:journalist) { create(:user, role: 'journalist') }
+    let(:journalist_headers) { journalist.create_new_auth_token }
+
+    before do
+      delete "/api/backyards/#{article.id}", headers: journalist_headers
+    end
+
+    it 'is expected to return status code 403' do
+      expect(response).to have_http_status 403
+    end
+
+    it 'is expected to return an error message' do
+      expect(response_json['error_message']).to eq 'You are not authorized to delete this article'
+    end
+  end
+end


### PR DESCRIPTION
[**PT-Story:**  ](https://www.pivotaltracker.com/story/show/178264708)
### User Story 
``` 
As a curator of community-based content
In order to avoid harmful activity
I want Editors to be able to remove community articles
``` 
## Changes proposed in this pull request: 
* Opens destroy route for `backyards`
* Allows only Editors to destroy backyard articles