### PR TITLE
Api provides functionality for visitors to see comments

### DIFF
--- a/app/controllers/api/statistics_controller.rb
+++ b/app/controllers/api/statistics_controller.rb
@@ -83,6 +83,6 @@ class Api::StatisticsController < ApplicationController
         timeline[i][:articles] += 1 if article[:created_at].strftime('%F') == date
       end
     end
-    @statistics[:articles_timeline] = timeline.reverse()
+    @statistics[:articles_timeline] = timeline.reverse
   end
 end

--- a/app/controllers/api/statistics_controller.rb
+++ b/app/controllers/api/statistics_controller.rb
@@ -5,6 +5,7 @@ class Api::StatisticsController < ApplicationController
     @statistics = {}
     get_local_statistics
     get_articles_timeline
+    @statistics[:comments] = { total: Comment.all.count }
     begin
       headers = { Authorization: 'Bearer sk_test_51IovvJL7WvJmM60HFPImrEIk25YfJ3ovv4YOLXN77R43J7ZmPth8fKKvi2qoneds5w50RAblSRPIlaIXo2PMFEhy00w7WvCun0' }
       response = RestClient.get('https://api.stripe.com/v1/subscriptions', headers)

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -13,6 +13,7 @@ class Article < ApplicationRecord
   validates :category, inclusion: { in: %w[Science Aliens Covid Illuminati Politics Hollywood] }, unless: :is_backyard?
   has_one_attached :image
   has_many :ratings
+  has_many :comments
 
   # Backyard articles
   validates :theme, :location, presence: true, if: :is_backyard?

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,0 +1,4 @@
+class Comment < ApplicationRecord
+  belongs_to :user
+  belongs_to :article
+end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,4 +1,6 @@
 class Comment < ApplicationRecord
   belongs_to :user
   belongs_to :article
+
+  validates_presence_of :body
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,5 +10,6 @@ class User < ActiveRecord::Base
 
   has_many :articles
   has_many :ratings
+  has_many :comments
   validates_presence_of :role, :first_name, :last_name
 end

--- a/app/serializers/articles_index_serializer.rb
+++ b/app/serializers/articles_index_serializer.rb
@@ -1,5 +1,5 @@
 class ArticlesIndexSerializer < ActiveModel::Serializer
-  attributes :id, :title, :teaser, :date, :category, :image, :rating, :author, :premium, :published
+  attributes :id, :title, :teaser, :date, :category, :image, :rating, :author, :premium, :published, :comments
 
   def date
     object.updated_at.strftime('%F, %H:%M')
@@ -22,5 +22,9 @@ class ArticlesIndexSerializer < ActiveModel::Serializer
       first_name: object.user.first_name,
       last_name: object.user.last_name
     }
+  end
+
+  def comments
+    object.comments.count
   end
 end

--- a/app/serializers/articles_show_serializer.rb
+++ b/app/serializers/articles_show_serializer.rb
@@ -1,5 +1,6 @@
 class ArticlesShowSerializer < ActiveModel::Serializer
-  attributes :id, :title, :teaser, :body, :date, :author, :category, :image, :rating, :author, :premium, :published
+  attributes :id, :title, :teaser, :body, :date, :author, :category, :image, :rating, :author, :premium, :published,
+             :comments
 
   def author
     {
@@ -22,5 +23,21 @@ class ArticlesShowSerializer < ActiveModel::Serializer
 
   def rating
     Rating.where(article_id: object.id).average(:rating).to_f
+  end
+
+  def comments
+    comments = []
+    object.comments.each do |comment|
+      comments.push({
+                      id: comment.id,
+                      user: "#{comment.user.first_name} #{comment.user.last_name}",
+                      date: comment.created_at.strftime('%F'),
+                      body: comment.body
+                    })
+    end
+    
+    binding.pry
+    
+    comments.reverse
   end
 end

--- a/app/serializers/articles_show_serializer.rb
+++ b/app/serializers/articles_show_serializer.rb
@@ -1,6 +1,6 @@
 class ArticlesShowSerializer < ActiveModel::Serializer
-  attributes :id, :title, :teaser, :body, :date, :author, :category, :image, :rating, :author, :premium, :published,
-             :comments
+  attributes :id, :title, :teaser, :body, :date, :author, :category, :image, :rating, :author, :premium, :published
+  has_many :comments, :serializer => CommentsIndexSerializer
 
   def author
     {
@@ -23,18 +23,5 @@ class ArticlesShowSerializer < ActiveModel::Serializer
 
   def rating
     Rating.where(article_id: object.id).average(:rating).to_f
-  end
-
-  def comments
-    comments = []
-    object.comments.each do |comment|
-      comments.push({
-                      id: comment.id,
-                      user: "#{comment.user.first_name} #{comment.user.last_name}",
-                      date: comment.created_at.strftime('%F'),
-                      body: comment.body
-                    })
-    end
-    comments.reverse
   end
 end

--- a/app/serializers/articles_show_serializer.rb
+++ b/app/serializers/articles_show_serializer.rb
@@ -35,9 +35,6 @@ class ArticlesShowSerializer < ActiveModel::Serializer
                       body: comment.body
                     })
     end
-    
-    binding.pry
-    
     comments.reverse
   end
 end

--- a/app/serializers/comments_index_serializer.rb
+++ b/app/serializers/comments_index_serializer.rb
@@ -1,0 +1,11 @@
+class CommentsIndexSerializer < ActiveModel::Serializer
+  attributes :id, :user, :date, :body
+
+  def user
+    "#{object.user.first_name} #{object.user.last_name}"
+  end
+
+  def date
+    object.created_at.strftime('%F')
+  end
+end

--- a/db/migrate/20210527184207_create_comments.rb
+++ b/db/migrate/20210527184207_create_comments.rb
@@ -1,0 +1,11 @@
+class CreateComments < ActiveRecord::Migration[6.1]
+  def change
+    create_table :comments do |t|
+      t.text :body
+      t.references :user, null: false, foreign_key: true
+      t.references :article, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_25_104906) do
+ActiveRecord::Schema.define(version: 2021_05_27_184207) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -59,6 +59,16 @@ ActiveRecord::Schema.define(version: 2021_05_25_104906) do
     t.index ["user_id"], name: "index_articles_on_user_id"
   end
 
+  create_table "comments", force: :cascade do |t|
+    t.text "body"
+    t.bigint "user_id", null: false
+    t.bigint "article_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["article_id"], name: "index_comments_on_article_id"
+    t.index ["user_id"], name: "index_comments_on_user_id"
+  end
+
   create_table "ratings", force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
@@ -100,4 +110,6 @@ ActiveRecord::Schema.define(version: 2021_05_25_104906) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "articles", "users"
+  add_foreign_key "comments", "articles"
+  add_foreign_key "comments", "users"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,9 +6,8 @@ titles = [
   'New Year 2020: 10 Moments This Decade That Made Us Say, "Wait, What?"',
   "Amateur Rocket-Maker Finally Launches Himself Off Earth - Now To Prove It's Flat",
   'The Covid-19 Vaccine Will Contain A Microchip',
-  'Canada SWAT team arrest pastor Artur Pawlowski, who’s been holding church services in defiance of the country’s strict COVID lockdown measures.',
+  'Canada SWAT team arrest pastor Artur Pawlowski.',
   'Moderna Chief Medical Officer Confirms mRNA Injection For COVID-19 Can Change Your Genetic Code.'
-
 ]
 teasers = [
   'Facebook has been criticized for failing to curb misinformation in English. But little attention has been paid to the scale of the problem in Arabic.',

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :comment do
+    body { "MyText" }
+    user { nil }
+    article { nil }
+  end
+end

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :comment do
-    body { "MyText" }
-    user { nil }
-    article { nil }
+    body { 'MyText' }
+    association :article
+    association :user
   end
 end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -44,8 +44,9 @@ RSpec.describe Article, type: :model do
     }
   end
 
-  describe 'Relationship between article and user' do
+  describe 'Relationships' do
     it { is_expected.to belong_to(:user) }
+    it { is_expected.to have_many(:comments) }
   end
 
   describe 'Relationship between article and ratings' do

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -1,0 +1,20 @@
+RSpec.describe Comment, type: :model do
+  describe 'DB tables' do
+    it { is_expected.to have_db_column(:body).of_type(:text) }
+  end
+
+  describe 'Validations' do
+    it { is_expected.to validate_presence_of :body }
+  end
+
+  describe 'Relationships' do
+    it { is_expected.to belong_to(:user) }
+    it { is_expected.to belong_to(:article) }
+  end
+
+  describe 'Factory' do
+    it 'is expected to have valid Factory' do
+      expect(create(:comment)).to be_valid
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -15,11 +15,9 @@ RSpec.describe User, type: :model do
     it { is_expected.to define_enum_for(:role).with_values({ member: 1, subscriber: 2, journalist: 5, editor: 10 }) }
   end
 
-  describe 'Relationship between article and user' do
+  describe 'Relationships' do
     it { is_expected.to have_many(:articles) }
-  end
-
-  describe 'Relationship between user and ratings' do
+    it { is_expected.to have_many(:comments) }
     it { is_expected.to have_many(:ratings) }
   end
 

--- a/spec/requests/api/editor/editor_can_see_all_articles_spec.rb
+++ b/spec/requests/api/editor/editor_can_see_all_articles_spec.rb
@@ -3,11 +3,12 @@ RSpec.describe 'GET /api/articles', type: :request do
   let!(:journalist) { create(:user, role: 'journalist') }
   let!(:journalist2) { create(:user, role: 'journalist') }
   let(:auth_headers) { editor.create_new_auth_token }
-
+  
   describe 'successfully' do
     let!(:article1) { create(:article, title: 'First Article', user_id: journalist.id) }
     let!(:article2) { create(:article, title: 'Second Article', user_id: journalist.id) }
     let!(:article3) { create(:article, title: 'Third Article', user_id: journalist2.id) }
+    let!(:comment) { create(:comment, article_id: article3.id) }
     before do
       get '/api/articles',
           headers: auth_headers
@@ -27,6 +28,10 @@ RSpec.describe 'GET /api/articles', type: :request do
 
     it 'is expected to have a published status of true' do
       expect(response_json['articles'].first['published']).to eq true
+    end
+
+    it 'is expected to contain amount of comments connected to the article' do
+      expect(response_json['articles'].first['comments']).to eq 1
     end
   end
 

--- a/spec/requests/api/editor/editor_can_see_company_statistics_spec.rb
+++ b/spec/requests/api/editor/editor_can_see_company_statistics_spec.rb
@@ -3,9 +3,10 @@ RSpec.describe 'GET /api/statistics', type: :request do
   let!(:editor_headers) { editor.create_new_auth_token }
   let!(:journalist) { create(:user, role: 'journalist') }
   let!(:journalist_headers) { journalist.create_new_auth_token }
-  let!(:published_articles1) { create(:article, created_at: Time.zone.now) }
-  let!(:published_articles2) { create(:article, created_at: Time.zone.now - 100_000)  }
-  let!(:published_articles3) { create(:article, created_at: Time.zone.now - 200_000)  }
+  let!(:published_article1) { create(:article, created_at: Time.zone.now) }
+  let!(:published_article2) { create(:article, created_at: Time.zone.now - 100_000)  }
+  let!(:published_article3) { create(:article, created_at: Time.zone.now - 200_000)  }
+  let!(:comment) { 3.times { create(:comment, article_id: published_article3.id, user_id: journalist.id) } }
   let!(:unpublished_articles) { create(:article, published: false) }
   let!(:backyard_articles) { 3.times { create(:backyard_article) } }
   let!(:subscriptions_data) do
@@ -45,6 +46,10 @@ RSpec.describe 'GET /api/statistics', type: :request do
 
     it 'is expected to return the total number of subscribers' do
       expect(response_json['statistics']['subscribers']['total']).to eq 10
+    end
+
+    it 'is expected to return the total number of comments' do
+      expect(response_json['statistics']['comments']['total']).to eq 3
     end
   end
 

--- a/spec/requests/api/visitor/can_see_comments_spec.rb
+++ b/spec/requests/api/visitor/can_see_comments_spec.rb
@@ -30,4 +30,18 @@ RSpec.describe 'GET /api/articles/:id', type: :request do
       expect(response_json['article']['comments'].first['date']).to eq Time.zone.now().strftime('%F') 
     end
   end
+
+  describe 'Unsuccessfully with no comments' do
+    before do
+      get "/api/articles/#{article.id}"
+    end
+
+    it 'is expected to return a 200 status' do
+      expect(response).to have_http_status 200
+    end
+
+    it 'is expected to return a comments object with an empty array' do
+      expect(response_json['article']['comments']).to eq []
+    end
+  end
 end

--- a/spec/requests/api/visitor/can_see_comments_spec.rb
+++ b/spec/requests/api/visitor/can_see_comments_spec.rb
@@ -1,0 +1,33 @@
+RSpec.describe 'GET /api/articles/:id', type: :request do
+  let!(:article) { create(:article) }
+
+  describe 'Successfully' do
+    let(:subscriber_1) { create(:subscriber) }
+    let(:subscriber_2) { create(:subscriber) }
+    before do
+      article.comments.create(user_id: subscriber_1.id, body: 'I see dead people!')
+      article.comments.create(user_id: subscriber_2.id, body: 'My husband is always coming home late from work...')
+      get "/api/articles/#{article.id}"
+    end
+    
+    it 'responds with a 200 status' do
+      expect(response).to have_http_status 200
+    end
+
+    it 'is expected to return an article with a list of 2 comments' do
+      expect(response_json['article']['comments'].count).to eq 2 
+    end
+
+    it 'is expected to return the comment\'s user' do
+      expect(response_json['article']['comments'].first['user']).to eq 'Mrs. Fake' 
+    end
+
+    it 'is expected to return the comment\'s body' do
+      expect(response_json['article']['comments'].first['body']).to eq 'My husband is always coming home late from work...' 
+    end
+
+    it 'is expected to return the comment\'s date of creation' do
+      expect(response_json['article']['comments'].first['body']).to eq Time.zone.now().strftime('%F') 
+    end
+  end
+end

--- a/spec/requests/api/visitor/can_see_comments_spec.rb
+++ b/spec/requests/api/visitor/can_see_comments_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'GET /api/articles/:id', type: :request do
     end
 
     it 'is expected to return the comment\'s date of creation' do
-      expect(response_json['article']['comments'].first['body']).to eq Time.zone.now().strftime('%F') 
+      expect(response_json['article']['comments'].first['date']).to eq Time.zone.now().strftime('%F') 
     end
   end
 end

--- a/spec/requests/api/visitor/can_see_comments_spec.rb
+++ b/spec/requests/api/visitor/can_see_comments_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'GET /api/articles/:id', type: :request do
     end
 
     it 'is expected to return the comment\'s body' do
-      expect(response_json['article']['comments'].first['body']).to eq 'My husband is always coming home late from work...' 
+      expect(response_json['article']['comments'].first['body']).to eq 'I see dead people!' 
     end
 
     it 'is expected to return the comment\'s date of creation' do


### PR DESCRIPTION
[**PT-Story:**  ](https://www.pivotaltracker.com/story/show/178309529)
### User Story 
``` 
As an API
In order for users to see other people's opinions
I need to be able to serve the client with comments
``` 
## Changes proposed in this pull request: 
* Adds Comment model
* Adds associations with User and Article
* Adds custom JSON format for the show serializer
* Adds comments count to index serializer
* Adds total comments count to statistics controller

## What I have learned working on this feature: 
* Some more experience creating object formats with loops :)