### PR TITLE
Api provides functionality for subscribers to comment on articles

### DIFF
--- a/app/controllers/api/backyards_controller.rb
+++ b/app/controllers/api/backyards_controller.rb
@@ -52,5 +52,4 @@ class Api::BackyardsController < ApplicationController
 
     render json: { error_message: 'You are not authorized to delete this article' }, status: 403
   end
-
 end

--- a/app/controllers/api/backyards_controller.rb
+++ b/app/controllers/api/backyards_controller.rb
@@ -52,4 +52,5 @@ class Api::BackyardsController < ApplicationController
 
     render json: { error_message: 'You are not authorized to delete this article' }, status: 403
   end
+
 end

--- a/app/controllers/api/comments_controller.rb
+++ b/app/controllers/api/comments_controller.rb
@@ -1,0 +1,12 @@
+class Api::CommentsController < ApplicationController
+  before_action :authenticate_user!
+
+  def create
+     comment = current_user.comments.create(params.permit(:article_id, :body))
+     if comment.persisted?
+     render json: { message: 'Your comment has been published'}, status: 201
+     else 
+      render json: { error_message: 'Comment can\'t be empty'}, status: 422
+     end
+  end  
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,9 @@ Rails.application.routes.draw do
   }
   namespace :api do
     resources :ratings, only: [:create]
-    resources :articles, only: %i[index show create update destroy]
+    resources :articles, only: %i[index show create update destroy] do
+      resources :comments, only: [:create]
+    end
     resources :backyards, only: %i[index show create destroy]
     resources :statistics, only: [:index]
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,4 +1,5 @@
 require 'uri'
+require 'faker'
 
 titles = [
   'New Vaccine Conspiracy Theories Are Going Viral in Arabic',
@@ -45,34 +46,46 @@ categories = %w[Science Aliens Covid Illuminati Politics Hollywood]
 
 themes = %w[Science Aliens Covid Trump Cats CIA Singles]
 
-puts 'Creating journalist...'
+puts 'Creating journalists...'
 journalist = User.create(email: 'mrfake@fakenews.com', password: 'password', password_confirmation: 'password',
                          first_name: 'Mr.', last_name: 'Fake', role: 5)
+(0..5).each do |i|
+User.create(email: Faker::Internet.email, password: 'password', first_name: Faker::Name.first_name, last_name: Faker::Name.last_name, role: 5)
+end
 
-puts 'Creating subscriber...'
+puts 'Creating subscribers...'
 subscriber = User.create(email: 'subscriber@gmail.com', password: 'password', password_confirmation: 'password',
                          first_name: 'Bob', last_name: 'Kramer', role: 2)
+(0..5).each do |i|
+  User.create(email: Faker::Internet.email, password: 'password', first_name: Faker::Name.first_name, last_name: Faker::Name.last_name, role: 2)
+end
 
 puts 'Creating editor....'
 editor = User.create(email: 'editor@gmail.com', password: 'password', password_confirmation: 'password',
                      first_name: 'Sam', last_name: 'Kramer', role: 10)
 
-puts 'Creating articles...'
+puts 'Spreading the truth...'
 (0...titles.count).each do |i|
   article = Article.create(title: titles[i], teaser: teasers[i], body: body[i], created_at: (DateTime.now - rand(7)),
                            category: categories[rand(categories.count - 1)], user_id: journalist.id, premium: [true, false].sample, published: true)
   Rating.create(user_id: journalist.id, article_id: article.id, rating: 3)
 end
 
-puts 'Attaching images to articles...'
+puts 'My opinion is gospel...'
+Article.where(backyard: false).each do |article|
+  rand(4).times { article.comments.create(body: Faker::ChuckNorris.fact, user_id: User.where(role: 2).sample.id) }
+end
+
+puts 'Attaching truthful images to articles...'
 Article.all.each_with_index do |article, index|
   file = URI.open(image_url[index])
 
   article.image.attach(io: file, filename: 'article_image.jpg', content_type: 'image/jpg')
 end
 
-puts 'Creating backyard articles...'
+puts 'Generating valid insights...'
 (0...titles.count).each do |i|
   backyard_article = Article.create(title: titles[i], body: body[i], backyard: true, location: %w[Sweden Denmark].sample,
                                     theme: themes[i], user_id: subscriber.id)
 end
+

--- a/spec/requests/api/subscriber/subscribers_can_write_comments_spec.rb
+++ b/spec/requests/api/subscriber/subscribers_can_write_comments_spec.rb
@@ -40,7 +40,22 @@ RSpec.describe 'POST /api/articles/:id/comments', type: :request do
     end
 
     it 'is expected to respond with an error message' do
-      expect(response_json['error_message']).to eq 'Please subscribe to be able to comment'
+      expect(response_json['errors'].first).to eq 'You need to sign in or sign up before continuing.'
+    end
+  end
+
+  describe "unsuccessfully with empty body parameter" do
+    before do
+      post "/api/articles/#{article.id}/comments",
+      headers: subscriber_headers
+    end
+
+    it "is expected to respond with a status of 422" do
+      expect(response).to have_http_status 422  
+    end
+
+    it "is expected to respond with an error message" do
+      expect(response_json['error_message']).to eq 'Comment can\'t be empty'  
     end
   end
 end

--- a/spec/requests/api/subscriber/subscribers_can_write_comments_spec.rb
+++ b/spec/requests/api/subscriber/subscribers_can_write_comments_spec.rb
@@ -1,0 +1,46 @@
+RSpec.describe 'POST /api/articles/:id/comments', type: :request do
+  let(:article) { create(:article) }
+  let(:subscriber) { create(:subscriber) }
+  let(:subscriber_headers) { subscriber.create_new_auth_token }
+
+  describe 'Successfully as a subscriber' do
+    before do
+      post "/api/articles/#{article.id}/comments", params: {
+        body: 'What a great website, I have subscribed solely based on the awesome design!'
+      },
+      headers: subscriber_headers
+    end
+
+    it 'is expected to return status 201' do
+      expect(response).to have_http_status 201
+    end
+
+    it 'is expected to respond with a success message' do
+      expect(response_json['message']).to eq 'Your comment has been published'
+    end
+
+    it 'is expected to add a comment to the article' do
+      expect(article.comments.count).to eq 1
+    end
+
+    it 'is expected to create an instance of a Comment with the expected body content' do
+      expect(Comment.last['body']).to eq 'What a great website, I have subscribed solely based on the awesome design!'
+    end
+  end
+
+  describe 'Unsuccessfully as a visitor' do
+    before do
+      post "/api/articles/#{article.id}/comments", params: {
+        body: 'ITS FAKE NEWS'
+      }
+    end
+
+    it 'is expected to return status 401' do
+      expect(response).to have_http_status 401
+    end
+
+    it 'is expected to respond with an error message' do
+      expect(response_json['error_message']).to eq 'Please subscribe to be able to comment'
+    end
+  end
+end


### PR DESCRIPTION
[**PT-Story:**  ](https://www.pivotaltracker.com/story/show/178175967)
### User Story 
``` 
As an API
In order to serve my paying consumers with the ability to express their opinion
I want subscribers to be able to comment on articles
``` 
## Changes proposed in this pull request: 
* Opens create route for Comments
* Restricts create action to Users

## What I have learned working on this feature: 
* A bit of seeding magic
* Using nested routing
