### PR TITLE
Editor needs to see ALL backyard articles (BUG)

### DIFF
--- a/app/controllers/api/articles_controller.rb
+++ b/app/controllers/api/articles_controller.rb
@@ -90,7 +90,7 @@ class Api::ArticlesController < ApplicationController
   end
 
   def publish_article(article)
-    if current_user&.editor?
+    if current_user.editor?
       article.update(published: true)
       render json: { message: 'Your article has been successfully updated!' }, status: 200
     else

--- a/app/controllers/api/backyards_controller.rb
+++ b/app/controllers/api/backyards_controller.rb
@@ -1,6 +1,7 @@
 class Api::BackyardsController < ApplicationController
   before_action :authenticate_user!, only: %i[create]
   before_action :editor_authenticator, only: %i[destroy]
+  before_action :editor_index_action, only: %i[index]
 
   def index
     country = get_country
@@ -48,8 +49,13 @@ class Api::BackyardsController < ApplicationController
   end
 
   def editor_authenticator
-    return if current_user.editor?
+    return if current_user&.editor?
 
     render json: { error_message: 'You are not authorized to delete this article' }, status: 403
+  end
+
+  def editor_index_action
+    render json: Article.where(backyard: true), each_serializer: BackyardsIndexSerializer if current_user&.editor?
+    return
   end
 end

--- a/app/serializers/backyards_index_serializer.rb
+++ b/app/serializers/backyards_index_serializer.rb
@@ -1,5 +1,5 @@
 class BackyardsIndexSerializer < ActiveModel::Serializer
-  attributes :id, :title, :theme, :date, :written_by,
+  attributes :id, :title, :theme, :date, :written_by, :location
 
   def date
     object.updated_at.strftime('%F, %H:%M')

--- a/spec/requests/api/editor/editor_can_see_all_backyard_articles_spec.rb
+++ b/spec/requests/api/editor/editor_can_see_all_backyard_articles_spec.rb
@@ -1,0 +1,38 @@
+RSpec.describe 'GET /api/backyards', type: :request do
+  let!(:editor) { create(:user, role: 'editor') }
+  let(:auth_headers) { editor.create_new_auth_token }
+  
+  describe 'successfully' do
+    let!(:backyard_article_1) { create(:article, title: 'First Article', location: 'Sweden') }
+    let!(:backyard_article_2) { create(:article, title: 'Second Article', location: 'Denmark') }
+    let!(:backyard_article_3) { create(:article, title: 'Second Article', location: 'Russia') }
+
+    before do
+      get '/api/articles',
+          headers: auth_headers
+    end
+
+    it 'is expected to response with status 200' do
+      expect(response).to have_http_status 200
+    end
+
+    it 'is expected to return 3 articles from all locations' do
+      expect(response_json['articles'].count).to eq 3
+    end
+  end
+
+  describe 'unsuccessfully as there is no articles' do
+    before do
+      get '/api/backyards',
+          headers: auth_headers
+    end
+
+    it 'is expected to response with status 200' do
+      expect(response).to have_http_status 200
+    end
+
+    it 'is expected to return an empty array' do
+      expect(response_json['articles']).to eq []
+    end
+  end
+end


### PR DESCRIPTION
[**PT-Story:**  ](https://www.pivotaltracker.com/story/show/178338126)
### User Story 
``` 
As an API
In order to have the Editor see ALL articles
I need a condition on the backyard articles index action
``` 
## Changes proposed in this pull request: 
* Adds conditional to /backyards if editor it will give all backyard articles