### PR TITLE
Refactor with a published, draft, archived system / visibility for backyard articles

### DIFF
--- a/app/controllers/api/articles_controller.rb
+++ b/app/controllers/api/articles_controller.rb
@@ -48,7 +48,7 @@ class Api::ArticlesController < ApplicationController
   def update
     article = Article.find(params[:id])
     if article_evaluation(article)
-      if params[:published]
+      if params[:status]
         publish_article(article)
       else
         update_article(article)
@@ -67,11 +67,11 @@ class Api::ArticlesController < ApplicationController
   private
 
   def set_language_for_index
-    if params[:language]
-      @language = params[:language].upcase
-    else
-      @language = 'EN'
-    end
+    @language = if params[:language]
+                  params[:language].upcase
+                else
+                  'EN'
+                end
   end
 
   def attach_image(article)
@@ -79,7 +79,7 @@ class Api::ArticlesController < ApplicationController
   end
 
   def article_params
-    params[:article].permit(:title, :teaser, :category, :premium, :body, :language)
+    params[:article].permit(:title, :teaser, :category, :status, :premium, :body, :language)
   end
 
   def article_evaluation(article)
@@ -100,7 +100,7 @@ class Api::ArticlesController < ApplicationController
 
   def publish_article(article)
     if current_user.editor?
-      article.update(published: true)
+      article.update(status: 'published')
       render json: { message: 'Your article has been successfully updated!' }, status: 200
     else
       render json: { error_message: 'You are not authorized to publish an article!' }, status: 403

--- a/app/controllers/api/articles_controller.rb
+++ b/app/controllers/api/articles_controller.rb
@@ -49,19 +49,13 @@ class Api::ArticlesController < ApplicationController
     article = Article.find(params[:id])
     if article_evaluation(article)
       if params[:status]
-        publish_article(article)
+        update_article_status(article, params[:status])
       else
         update_article(article)
       end
     else
       render json: { error_message: 'You are not authorized to edit this article' }, status: 403
     end
-  end
-
-  def destroy
-    article = Article.find(params[:id])
-    article.destroy
-    render json: { message: 'The article was successfully deleted' }
   end
 
   private
@@ -98,9 +92,9 @@ class Api::ArticlesController < ApplicationController
     render json: { error_message: 'You are not authorized to delete this article' }, status: 403
   end
 
-  def publish_article(article)
+  def update_article_status(article, status)
     if current_user.editor?
-      article.update(status: 'published')
+      article.update(status: status)
       render json: { message: 'Your article has been successfully updated!' }, status: 200
     else
       render json: { error_message: 'You are not authorized to publish an article!' }, status: 403

--- a/app/controllers/api/backyards_controller.rb
+++ b/app/controllers/api/backyards_controller.rb
@@ -1,6 +1,6 @@
 class Api::BackyardsController < ApplicationController
   before_action :authenticate_user!, only: %i[create]
-  before_action :editor_authenticator, only: %i[destroy]
+  before_action :editor_authenticator, only: %i[update]
   before_action :editor_index_action, only: %i[index]
 
   def index
@@ -24,13 +24,18 @@ class Api::BackyardsController < ApplicationController
     end
   end
 
-  def destroy
-    article = Article.find(params[:id])
-    article.destroy
-    render json: { message: 'The article was successfully deleted' }
+  def update
+    backyard_article = Article.find(params[:id])
+    archive_article(backyard_article)   
   end
 
   private
+
+  def archive_article(backyard_article)
+    backyard_article.archived!
+    backyard_article.save
+    render json: { message: 'This backyard article has been successfully archived' }, status: 200
+  end
 
   def get_country
     country_response = Geocoder.search([params[:lat], params[:lon]])
@@ -52,7 +57,7 @@ class Api::BackyardsController < ApplicationController
   def editor_authenticator
     return if current_user&.editor?
 
-    render json: { error_message: 'You are not authorized to delete this article' }, status: 403
+    render json: { error_message: 'You are not authorized to archive this article' }, status: 403
   end
 
   def editor_index_action

--- a/app/controllers/api/backyards_controller.rb
+++ b/app/controllers/api/backyards_controller.rb
@@ -44,6 +44,7 @@ class Api::BackyardsController < ApplicationController
   def build_backyard_article
     backyard_article = current_user.articles.build(article_params)
     backyard_article['backyard'] = true
+    backyard_article['status'] = 'published'
     backyard_article.save
     backyard_article
   end
@@ -56,6 +57,6 @@ class Api::BackyardsController < ApplicationController
 
   def editor_index_action
     render json: Article.where(backyard: true), each_serializer: BackyardsIndexSerializer if current_user&.editor?
-    return
+    nil
   end
 end

--- a/app/controllers/api/backyards_controller.rb
+++ b/app/controllers/api/backyards_controller.rb
@@ -26,16 +26,11 @@ class Api::BackyardsController < ApplicationController
 
   def update
     backyard_article = Article.find(params[:id])
-    archive_article(backyard_article)   
+    backyard_article.update(status: params['status'])
+    render json: { message: 'This backyard article has been successfully updated' }, status: 200
   end
 
   private
-
-  def archive_article(backyard_article)
-    backyard_article.archived!
-    backyard_article.save
-    render json: { message: 'This backyard article has been successfully archived' }, status: 200
-  end
 
   def get_country
     country_response = Geocoder.search([params[:lat], params[:lon]])
@@ -57,7 +52,7 @@ class Api::BackyardsController < ApplicationController
   def editor_authenticator
     return if current_user&.editor?
 
-    render json: { error_message: 'You are not authorized to archive this article' }, status: 403
+    render json: { error_message: 'You are not authorized to update this article' }, status: 403
   end
 
   def editor_index_action

--- a/app/controllers/api/statistics_controller.rb
+++ b/app/controllers/api/statistics_controller.rb
@@ -24,8 +24,9 @@ class Api::StatisticsController < ApplicationController
   def get_local_statistics
     @statistics[:articles] = {
       total: Article.where(backyard: false).count,
-      published: Article.where(published: true, backyard: false).count,
-      unpublished: Article.where(published: false, backyard: false).count
+      published: Article.where(status: 'published', backyard: false).count,
+      drafts: Article.where(status: 'draft', backyard: false).count,
+      archived: Article.where(status: 'archived', backyard: false).count
     }
     @statistics[:backyard_articles] = { total: Article.where(backyard: true).count }
     @statistics[:journalists] = { total: User.where(role: 5).count }

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -4,13 +4,12 @@ class Article < ApplicationRecord
   belongs_to :user
 
   scope :most_recent, -> { order(updated_at: :desc) }
-  scope :public_articles, -> { where(backyard: false, published: true) }
-  enum status: {arcived: 1, draft: 5, published: 10}
+  scope :public_articles, -> { where(backyard: false, status: 'published') }
+  enum status: {archived: 1, draft: 5, published: 10}
 
   # Normal articles
   validates :category, :language, :teaser, presence: true, unless: :is_backyard?
   validates :premium, inclusion: { in: [false, true] }, unless: :is_backyard?
-  validates :published, inclusion: { in: [false, true] }, unless: :is_backyard?
   validates :category, inclusion: { in: %w[Science Aliens Covid Illuminati Politics Hollywood] }, unless: :is_backyard?
   has_one_attached :image
   has_many :ratings

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,6 +1,6 @@
 class Article < ApplicationRecord
   validates_inclusion_of :backyard, in: [false, true]
-  validates_presence_of :title, :body
+  validates_presence_of :title, :body, :status
   belongs_to :user
 
   scope :most_recent, -> { order(updated_at: :desc) }

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -5,6 +5,7 @@ class Article < ApplicationRecord
 
   scope :most_recent, -> { order(updated_at: :desc) }
   scope :public_articles, -> { where(backyard: false, published: true) }
+  enum status: {arcived: 1, draft: 5, published: 10}
 
   # Normal articles
   validates :category, :language, :teaser, presence: true, unless: :is_backyard?

--- a/app/serializers/articles_index_serializer.rb
+++ b/app/serializers/articles_index_serializer.rb
@@ -1,9 +1,13 @@
 class ArticlesIndexSerializer < ActiveModel::Serializer
-  attributes :id, :title, :teaser, :date, :category, :language, :image, :rating, :author, :premium, :published,
-             :comments
+  attributes :id, :title, :teaser, :date, :category, :status, :language, :image, :rating, :author, :premium, :comments
 
   def date
     object.updated_at.strftime('%F, %H:%M')
+  end
+
+  def status
+    object.status.capitalize
+    
   end
 
   def image

--- a/app/serializers/articles_index_serializer.rb
+++ b/app/serializers/articles_index_serializer.rb
@@ -6,8 +6,7 @@ class ArticlesIndexSerializer < ActiveModel::Serializer
   end
 
   def status
-    object.status.capitalize
-    
+    object.status.capitalize    
   end
 
   def image

--- a/app/serializers/articles_show_serializer.rb
+++ b/app/serializers/articles_show_serializer.rb
@@ -1,5 +1,5 @@
 class ArticlesShowSerializer < ActiveModel::Serializer
-  attributes :id, :title, :teaser, :body, :date, :author, :category, :image, :rating, :author, :premium, :published
+  attributes :id, :title, :teaser, :body, :date, :author, :category, :status, :image, :rating, :author, :premium
   has_many :comments, :serializer => CommentsIndexSerializer
 
   def author
@@ -7,6 +7,10 @@ class ArticlesShowSerializer < ActiveModel::Serializer
       first_name: object.user.first_name,
       last_name: object.user.last_name
     }
+  end
+  
+  def status
+    object.status.capitalize    
   end
 
   def date

--- a/app/serializers/backyards_index_serializer.rb
+++ b/app/serializers/backyards_index_serializer.rb
@@ -1,5 +1,5 @@
 class BackyardsIndexSerializer < ActiveModel::Serializer
-  attributes :id, :title, :theme, :date, :written_by, :location
+  attributes :id, :title, :theme, :date, :written_by, :location, :status
 
   def date
     object.updated_at.strftime('%F, %H:%M')
@@ -7,5 +7,9 @@ class BackyardsIndexSerializer < ActiveModel::Serializer
 
   def written_by
     "#{object.user.first_name} #{object.user.last_name}"
+  end
+
+  def status
+    object.status.capitalize
   end
 end

--- a/app/serializers/backyards_show_serializer_serializer.rb
+++ b/app/serializers/backyards_show_serializer_serializer.rb
@@ -1,5 +1,5 @@
 class BackyardsShowSerializerSerializer < ActiveModel::Serializer
-  attributes :id, :title, :body, :theme, :date, :written_by, :location
+  attributes :id, :title, :body, :theme, :date, :written_by, :location, :status
 
   def date
     object.updated_at.strftime('%F, %H:%M')
@@ -7,5 +7,9 @@ class BackyardsShowSerializerSerializer < ActiveModel::Serializer
 
   def written_by
     "#{object.user.first_name} #{object.user.last_name}"
+  end
+
+  def status
+    object.status.capitalize
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,7 @@ Rails.application.routes.draw do
     resources :articles, only: %i[index show create update destroy] do
       resources :comments, only: [:create]
     end
-    resources :backyards, only: %i[index show create destroy]
+    resources :backyards, only: %i[index show create update]
     resources :statistics, only: [:index]
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
   }
   namespace :api do
     resources :ratings, only: [:create]
-    resources :articles, only: %i[index show create update destroy] do
+    resources :articles, only: %i[index show create update] do
       resources :comments, only: [:create]
     end
     resources :backyards, only: %i[index show create update]

--- a/db/migrate/20210524194436_add_published_to_articles.rb
+++ b/db/migrate/20210524194436_add_published_to_articles.rb
@@ -1,5 +1,0 @@
-class AddPublishedToArticles < ActiveRecord::Migration[6.1]
-  def change
-    add_column :articles, :published, :boolean, default: false
-  end
-end

--- a/db/migrate/20210529175835_add_status_to_article.rb
+++ b/db/migrate/20210529175835_add_status_to_article.rb
@@ -1,0 +1,5 @@
+class AddStatusToArticle < ActiveRecord::Migration[6.1]
+  def change
+    add_column :articles, :status, :integer
+  end
+end

--- a/db/migrate/20210529175835_add_status_to_article.rb
+++ b/db/migrate/20210529175835_add_status_to_article.rb
@@ -1,5 +1,5 @@
 class AddStatusToArticle < ActiveRecord::Migration[6.1]
   def change
-    add_column :articles, :status, :integer
+    add_column :articles, :status, :integer, default: 5
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -56,7 +56,7 @@ ActiveRecord::Schema.define(version: 2021_05_29_175835) do
     t.string "theme"
     t.boolean "backyard", default: false
     t.string "language"
-    t.integer "status"
+    t.integer "status", default: 5
     t.index ["user_id"], name: "index_articles_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_29_133252) do
+ActiveRecord::Schema.define(version: 2021_05_29_175835) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -57,6 +57,7 @@ ActiveRecord::Schema.define(version: 2021_05_29_133252) do
     t.boolean "backyard", default: false
     t.boolean "published", default: false
     t.string "language"
+    t.integer "status"
     t.index ["user_id"], name: "index_articles_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,108 +10,107 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_210_529_175_835) do
+ActiveRecord::Schema.define(version: 2021_05_29_175835) do
+
   # These are extensions that must be enabled in order to support this database
-  enable_extension 'plpgsql'
+  enable_extension "plpgsql"
 
-  create_table 'active_storage_attachments', force: :cascade do |t|
-    t.string 'name', null: false
-    t.string 'record_type', null: false
-    t.bigint 'record_id', null: false
-    t.bigint 'blob_id', null: false
-    t.datetime 'created_at', null: false
-    t.index ['blob_id'], name: 'index_active_storage_attachments_on_blob_id'
-    t.index %w[record_type record_id name blob_id], name: 'index_active_storage_attachments_uniqueness',
-                                                    unique: true
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
   end
 
-  create_table 'active_storage_blobs', force: :cascade do |t|
-    t.string 'key', null: false
-    t.string 'filename', null: false
-    t.string 'content_type'
-    t.text 'metadata'
-    t.string 'service_name', null: false
-    t.bigint 'byte_size', null: false
-    t.string 'checksum', null: false
-    t.datetime 'created_at', null: false
-    t.index ['key'], name: 'index_active_storage_blobs_on_key', unique: true
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum", null: false
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
-  create_table 'active_storage_variant_records', force: :cascade do |t|
-    t.bigint 'blob_id', null: false
-    t.string 'variation_digest', null: false
-    t.index %w[blob_id variation_digest], name: 'index_active_storage_variant_records_uniqueness', unique: true
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
-  create_table 'articles', force: :cascade do |t|
-    t.string 'title'
-    t.text 'teaser'
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.text 'body'
-    t.bigint 'user_id'
-    t.string 'category'
-    t.boolean 'premium', default: false
-    t.string 'location'
-    t.string 'theme'
-    t.boolean 'backyard', default: false
-    t.boolean 'published', default: false
-    t.string 'language'
-    t.integer 'status'
-    t.index ['user_id'], name: 'index_articles_on_user_id'
+  create_table "articles", force: :cascade do |t|
+    t.string "title"
+    t.text "teaser"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.text "body"
+    t.bigint "user_id"
+    t.string "category"
+    t.boolean "premium", default: false
+    t.string "location"
+    t.string "theme"
+    t.boolean "backyard", default: false
+    t.string "language"
+    t.integer "status"
+    t.index ["user_id"], name: "index_articles_on_user_id"
   end
 
-  create_table 'comments', force: :cascade do |t|
-    t.text 'body'
-    t.bigint 'user_id', null: false
-    t.bigint 'article_id', null: false
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.index ['article_id'], name: 'index_comments_on_article_id'
-    t.index ['user_id'], name: 'index_comments_on_user_id'
+  create_table "comments", force: :cascade do |t|
+    t.text "body"
+    t.bigint "user_id", null: false
+    t.bigint "article_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["article_id"], name: "index_comments_on_article_id"
+    t.index ["user_id"], name: "index_comments_on_user_id"
   end
 
-  create_table 'ratings', force: :cascade do |t|
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.integer 'rating'
-    t.integer 'article_id'
-    t.integer 'user_id'
+  create_table "ratings", force: :cascade do |t|
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.integer "rating"
+    t.integer "article_id"
+    t.integer "user_id"
   end
 
-  create_table 'users', force: :cascade do |t|
-    t.string 'provider', default: 'email', null: false
-    t.string 'uid', default: '', null: false
-    t.string 'encrypted_password', default: '', null: false
-    t.string 'reset_password_token'
-    t.datetime 'reset_password_sent_at'
-    t.boolean 'allow_password_change', default: false
-    t.datetime 'remember_created_at'
-    t.string 'confirmation_token'
-    t.datetime 'confirmed_at'
-    t.datetime 'confirmation_sent_at'
-    t.string 'unconfirmed_email'
-    t.string 'email'
-    t.json 'tokens'
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.integer 'sign_in_count', default: 0
-    t.datetime 'current_sign_in_at'
-    t.datetime 'last_sign_in_at'
-    t.string 'current_sign_in_ip'
-    t.string 'last_sign_in_ip'
-    t.integer 'role'
-    t.string 'first_name'
-    t.string 'last_name'
-    t.index ['confirmation_token'], name: 'index_users_on_confirmation_token', unique: true
-    t.index ['email'], name: 'index_users_on_email', unique: true
-    t.index ['reset_password_token'], name: 'index_users_on_reset_password_token', unique: true
-    t.index %w[uid provider], name: 'index_users_on_uid_and_provider', unique: true
+  create_table "users", force: :cascade do |t|
+    t.string "provider", default: "email", null: false
+    t.string "uid", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.boolean "allow_password_change", default: false
+    t.datetime "remember_created_at"
+    t.string "confirmation_token"
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
+    t.string "unconfirmed_email"
+    t.string "email"
+    t.json "tokens"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.integer "sign_in_count", default: 0
+    t.datetime "current_sign_in_at"
+    t.datetime "last_sign_in_at"
+    t.string "current_sign_in_ip"
+    t.string "last_sign_in_ip"
+    t.integer "role"
+    t.string "first_name"
+    t.string "last_name"
+    t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+    t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
   end
 
-  add_foreign_key 'active_storage_attachments', 'active_storage_blobs', column: 'blob_id'
-  add_foreign_key 'active_storage_variant_records', 'active_storage_blobs', column: 'blob_id'
-  add_foreign_key 'articles', 'users'
-  add_foreign_key 'comments', 'articles'
-  add_foreign_key 'comments', 'users'
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "articles", "users"
+  add_foreign_key "comments", "articles"
+  add_foreign_key "comments", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,108 +10,108 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_29_175835) do
-
+ActiveRecord::Schema.define(version: 20_210_529_175_835) do
   # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
+  enable_extension 'plpgsql'
 
-  create_table "active_storage_attachments", force: :cascade do |t|
-    t.string "name", null: false
-    t.string "record_type", null: false
-    t.bigint "record_id", null: false
-    t.bigint "blob_id", null: false
-    t.datetime "created_at", null: false
-    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
-    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  create_table 'active_storage_attachments', force: :cascade do |t|
+    t.string 'name', null: false
+    t.string 'record_type', null: false
+    t.bigint 'record_id', null: false
+    t.bigint 'blob_id', null: false
+    t.datetime 'created_at', null: false
+    t.index ['blob_id'], name: 'index_active_storage_attachments_on_blob_id'
+    t.index %w[record_type record_id name blob_id], name: 'index_active_storage_attachments_uniqueness',
+                                                    unique: true
   end
 
-  create_table "active_storage_blobs", force: :cascade do |t|
-    t.string "key", null: false
-    t.string "filename", null: false
-    t.string "content_type"
-    t.text "metadata"
-    t.string "service_name", null: false
-    t.bigint "byte_size", null: false
-    t.string "checksum", null: false
-    t.datetime "created_at", null: false
-    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  create_table 'active_storage_blobs', force: :cascade do |t|
+    t.string 'key', null: false
+    t.string 'filename', null: false
+    t.string 'content_type'
+    t.text 'metadata'
+    t.string 'service_name', null: false
+    t.bigint 'byte_size', null: false
+    t.string 'checksum', null: false
+    t.datetime 'created_at', null: false
+    t.index ['key'], name: 'index_active_storage_blobs_on_key', unique: true
   end
 
-  create_table "active_storage_variant_records", force: :cascade do |t|
-    t.bigint "blob_id", null: false
-    t.string "variation_digest", null: false
-    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  create_table 'active_storage_variant_records', force: :cascade do |t|
+    t.bigint 'blob_id', null: false
+    t.string 'variation_digest', null: false
+    t.index %w[blob_id variation_digest], name: 'index_active_storage_variant_records_uniqueness', unique: true
   end
 
-  create_table "articles", force: :cascade do |t|
-    t.string "title"
-    t.text "teaser"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.text "body"
-    t.bigint "user_id"
-    t.string "category"
-    t.boolean "premium", default: false
-    t.string "location"
-    t.string "theme"
-    t.boolean "backyard", default: false
-    t.boolean "published", default: false
-    t.string "language"
-    t.integer "status"
-    t.index ["user_id"], name: "index_articles_on_user_id"
+  create_table 'articles', force: :cascade do |t|
+    t.string 'title'
+    t.text 'teaser'
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+    t.text 'body'
+    t.bigint 'user_id'
+    t.string 'category'
+    t.boolean 'premium', default: false
+    t.string 'location'
+    t.string 'theme'
+    t.boolean 'backyard', default: false
+    t.boolean 'published', default: false
+    t.string 'language'
+    t.integer 'status'
+    t.index ['user_id'], name: 'index_articles_on_user_id'
   end
 
-  create_table "comments", force: :cascade do |t|
-    t.text "body"
-    t.bigint "user_id", null: false
-    t.bigint "article_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["article_id"], name: "index_comments_on_article_id"
-    t.index ["user_id"], name: "index_comments_on_user_id"
+  create_table 'comments', force: :cascade do |t|
+    t.text 'body'
+    t.bigint 'user_id', null: false
+    t.bigint 'article_id', null: false
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+    t.index ['article_id'], name: 'index_comments_on_article_id'
+    t.index ['user_id'], name: 'index_comments_on_user_id'
   end
 
-  create_table "ratings", force: :cascade do |t|
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.integer "rating"
-    t.integer "article_id"
-    t.integer "user_id"
+  create_table 'ratings', force: :cascade do |t|
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+    t.integer 'rating'
+    t.integer 'article_id'
+    t.integer 'user_id'
   end
 
-  create_table "users", force: :cascade do |t|
-    t.string "provider", default: "email", null: false
-    t.string "uid", default: "", null: false
-    t.string "encrypted_password", default: "", null: false
-    t.string "reset_password_token"
-    t.datetime "reset_password_sent_at"
-    t.boolean "allow_password_change", default: false
-    t.datetime "remember_created_at"
-    t.string "confirmation_token"
-    t.datetime "confirmed_at"
-    t.datetime "confirmation_sent_at"
-    t.string "unconfirmed_email"
-    t.string "email"
-    t.json "tokens"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.integer "sign_in_count", default: 0
-    t.datetime "current_sign_in_at"
-    t.datetime "last_sign_in_at"
-    t.string "current_sign_in_ip"
-    t.string "last_sign_in_ip"
-    t.integer "role"
-    t.string "first_name"
-    t.string "last_name"
-    t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
-    t.index ["email"], name: "index_users_on_email", unique: true
-    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
-    t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
+  create_table 'users', force: :cascade do |t|
+    t.string 'provider', default: 'email', null: false
+    t.string 'uid', default: '', null: false
+    t.string 'encrypted_password', default: '', null: false
+    t.string 'reset_password_token'
+    t.datetime 'reset_password_sent_at'
+    t.boolean 'allow_password_change', default: false
+    t.datetime 'remember_created_at'
+    t.string 'confirmation_token'
+    t.datetime 'confirmed_at'
+    t.datetime 'confirmation_sent_at'
+    t.string 'unconfirmed_email'
+    t.string 'email'
+    t.json 'tokens'
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+    t.integer 'sign_in_count', default: 0
+    t.datetime 'current_sign_in_at'
+    t.datetime 'last_sign_in_at'
+    t.string 'current_sign_in_ip'
+    t.string 'last_sign_in_ip'
+    t.integer 'role'
+    t.string 'first_name'
+    t.string 'last_name'
+    t.index ['confirmation_token'], name: 'index_users_on_confirmation_token', unique: true
+    t.index ['email'], name: 'index_users_on_email', unique: true
+    t.index ['reset_password_token'], name: 'index_users_on_reset_password_token', unique: true
+    t.index %w[uid provider], name: 'index_users_on_uid_and_provider', unique: true
   end
 
-  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
-  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
-  add_foreign_key "articles", "users"
-  add_foreign_key "comments", "articles"
-  add_foreign_key "comments", "users"
+  add_foreign_key 'active_storage_attachments', 'active_storage_blobs', column: 'blob_id'
+  add_foreign_key 'active_storage_variant_records', 'active_storage_blobs', column: 'blob_id'
+  add_foreign_key 'articles', 'users'
+  add_foreign_key 'comments', 'articles'
+  add_foreign_key 'comments', 'users'
 end

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -7,8 +7,7 @@ FactoryBot.define do
     backyard { false }
     category { 'Science' }
     premium { true }
-    published { true }
-    status { 5 }
+    status { 10 }
     language { 'EN' }
     after(:build) do |article|
       file = File.open(Rails.root.join('spec', 'fixtures', 'fake-news-fixture.jpg'))

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -8,6 +8,7 @@ FactoryBot.define do
     category { 'Science' }
     premium { true }
     published { true }
+    status { 5 }
     language { 'EN' }
     after(:build) do |article|
       file = File.open(Rails.root.join('spec', 'fixtures', 'fake-news-fixture.jpg'))
@@ -22,5 +23,6 @@ FactoryBot.define do
     association :user
     backyard { true }
     location { 'Sweden' }
+    status { 10 }
   end
 end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -13,13 +13,14 @@ RSpec.describe Article, type: :model do
   end
 
   describe 'status' do
-    it { is_expected.to define_enum_for(:status).with_values({arcived: 1, draft: 5, published: 10}) }
+    it { is_expected.to define_enum_for(:status).with_values({ arcived: 1, draft: 5, published: 10 }) }
   end
 
   describe 'Validation' do
     it { is_expected.to validate_presence_of :title }
     it { is_expected.to validate_presence_of :body }
     it { is_expected.to validate_inclusion_of(:backyard).in_array([false, true]) }
+    it { is_expected.to validate_presence_of(:status) }
 
     context 'Normal article' do
       before { allow(subject).to receive(:is_backyard?).and_return(false) }
@@ -32,7 +33,7 @@ RSpec.describe Article, type: :model do
         is_expected.to validate_inclusion_of(:category)
           .in_array(%w[Science Aliens Covid Illuminati Politics Hollywood])
       }
-      it { is_expected.to validate_inclusion_of(:published).in_array([false, true])}
+      it { is_expected.to validate_inclusion_of(:published).in_array([false, true]) }
     end
 
     context 'Backyard article' do

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -8,12 +8,12 @@ RSpec.describe Article, type: :model do
     it { is_expected.to have_db_column(:theme).of_type(:string) }
     it { is_expected.to have_db_column(:backyard).of_type(:boolean) }
     it { is_expected.to have_db_column(:premium).of_type(:boolean) }
-    it { is_expected.to have_db_column(:published).of_type(:boolean) }
+
     it { is_expected.to have_db_column(:language).of_type(:string) }
   end
 
   describe 'status' do
-    it { is_expected.to define_enum_for(:status).with_values({ arcived: 1, draft: 5, published: 10 }) }
+    it { is_expected.to define_enum_for(:status).with_values({ archived: 1, draft: 5, published: 10 }) }
   end
 
   describe 'Validation' do
@@ -33,7 +33,7 @@ RSpec.describe Article, type: :model do
         is_expected.to validate_inclusion_of(:category)
           .in_array(%w[Science Aliens Covid Illuminati Politics Hollywood])
       }
-      it { is_expected.to validate_inclusion_of(:published).in_array([false, true]) }
+      
     end
 
     context 'Backyard article' do

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -12,6 +12,10 @@ RSpec.describe Article, type: :model do
     it { is_expected.to have_db_column(:language).of_type(:string) }
   end
 
+  describe 'status' do
+    it { is_expected.to define_enum_for(:status).with_values({arcived: 1, draft: 5, published: 10}) }
+  end
+
   describe 'Validation' do
     it { is_expected.to validate_presence_of :title }
     it { is_expected.to validate_presence_of :body }

--- a/spec/requests/api/editor/editor_can_publish_articles_spec.rb
+++ b/spec/requests/api/editor/editor_can_publish_articles_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe 'PUT api/articles', type: :request do
   let!(:editor) { create(:user, role: 'editor') }
   let!(:journalist) { create(:user, role: 'journalist') }
-  let!(:article) { create(:article, title: 'Old Article', user_id: journalist.id, status: archived) }
+  let!(:article) { create(:article, title: 'Old Article', user_id: journalist.id, status: 'draft') }
   let!(:auth_headers) { editor.create_new_auth_token }
   let!(:auth_headers_journalist) { journalist.create_new_auth_token }
 
@@ -9,7 +9,7 @@ RSpec.describe 'PUT api/articles', type: :request do
     before do
       put "/api/articles/#{article.id}",
           params: {
-            status: published
+            status: 'published'
           },
           headers: auth_headers
     end
@@ -31,7 +31,7 @@ RSpec.describe 'PUT api/articles', type: :request do
     before do
       put "/api/articles/#{article.id}",
           params: {
-            status: published
+            status: 'published'
           },
           headers: auth_headers_journalist
     end

--- a/spec/requests/api/editor/editor_can_publish_articles_spec.rb
+++ b/spec/requests/api/editor/editor_can_publish_articles_spec.rb
@@ -1,15 +1,15 @@
 RSpec.describe 'PUT api/articles', type: :request do
   let!(:editor) { create(:user, role: 'editor') }
   let!(:journalist) { create(:user, role: 'journalist') }
-  let!(:article) { create(:article, title: 'Old Article', user_id: journalist.id, published: false) }
+  let!(:article) { create(:article, title: 'Old Article', user_id: journalist.id, status: archived) }
   let!(:auth_headers) { editor.create_new_auth_token }
   let!(:auth_headers_journalist) { journalist.create_new_auth_token }
 
   describe 'successfully as an editor' do
     before do
       put "/api/articles/#{article.id}",
-          params: { 
-              published: true
+          params: {
+            status: published
           },
           headers: auth_headers
     end
@@ -30,8 +30,8 @@ RSpec.describe 'PUT api/articles', type: :request do
   describe 'unsuccessfully as a journalist' do
     before do
       put "/api/articles/#{article.id}",
-          params: { 
-              published: true
+          params: {
+            status: published
           },
           headers: auth_headers_journalist
     end

--- a/spec/requests/api/editor/editor_can_publish_backyard_articles_spec.rb
+++ b/spec/requests/api/editor/editor_can_publish_backyard_articles_spec.rb
@@ -1,0 +1,47 @@
+RSpec.describe 'PUT /api/backyards/', type: :request do
+  let!(:editor) { create(:user, role: 'editor') }
+  let!(:journalist) { create(:user, role: 'journalist') }
+  let!(:backyard_article) { create(:backyard_article, status: 'archived') }
+  let!(:auth_headers) { editor.create_new_auth_token }
+  let!(:auth_headers_journalist) { journalist.create_new_auth_token }
+
+  describe 'successfully as an editor' do
+    before do
+      put "/api/backyards/#{backyard_article.id}",
+          params: {
+            status: 'published'
+          },
+          headers: auth_headers
+    end
+
+    it 'is expected to return a 200 status' do
+      expect(response).to have_http_status 200
+    end
+
+    it 'is expected to return a success message' do
+      expect(response_json['message']).to eq 'This backyard article has been successfully updated'
+    end
+
+    it 'is expected to set published status to true' do
+      expect(backyard_article.reload.published?).to eq true
+    end
+  end
+
+  describe 'unsuccessfully as a journalist' do
+    before do
+      put "/api/backyards/#{backyard_article.id}",
+          params: {
+            status: 'published'
+          },
+          headers: auth_headers_journalist
+    end
+
+    it 'is expected to return a 403 status' do
+      expect(response).to have_http_status 403
+    end
+
+    it 'is expected to return a error message' do
+      expect(response_json['error_message']).to eq 'You are not authorized to update this article'
+    end
+  end
+end

--- a/spec/requests/api/editor/editor_can_put_articles_to_archive_spec.rb
+++ b/spec/requests/api/editor/editor_can_put_articles_to_archive_spec.rb
@@ -1,11 +1,13 @@
-RSpec.describe 'DELETE /api/articles/:id' do
+RSpec.describe 'PUT /api/articles/:id' do
   let(:article) { create(:article) }
   let(:editor) { create(:user, role: 'editor') }
   let(:editor_headers) { editor.create_new_auth_token }
 
   describe 'Successfully' do
     before do
-      delete "/api/articles/#{article.id}", headers: editor_headers
+      put "/api/articles/#{article.id}",
+          params: { status: 'archived' },
+          headers: editor_headers
     end
 
     it 'is expected to return status code 200' do
@@ -13,17 +15,19 @@ RSpec.describe 'DELETE /api/articles/:id' do
     end
 
     it 'is expected to return a success message' do
-      expect(response_json['message']).to eq 'The article was successfully deleted'
+      expect(response_json['message']).to eq 'Your article has been successfully updated!'
     end
 
-    it 'is expected to have deleted article' do
-      expect(Article.all.count).to eq 0
+    it 'is expected to have archive article' do
+      expect(Article.where(status: 'archived').count).to eq 1
     end
   end
 
   describe 'Unsuccessfully because article does not exist' do
     before do
-      delete '/api/articles/1337', headers: editor_headers
+      put "/api/articles/#{article.id + 1}",
+          params: { status: 'archived' },
+          headers: editor_headers
     end
 
     it 'is expected to return status code 404' do
@@ -31,7 +35,7 @@ RSpec.describe 'DELETE /api/articles/:id' do
     end
 
     it 'is expected to return an error message' do
-      expect(response_json['error_message']).to eq "Couldn't find Article with 'id'=1337"
+      expect(response_json['error_message']).to eq "Couldn't find Article with 'id'=#{article.id + 1}"
     end
   end
 
@@ -40,7 +44,9 @@ RSpec.describe 'DELETE /api/articles/:id' do
     let(:journalist_headers) { journalist.create_new_auth_token }
 
     before do
-      delete "/api/articles/#{article.id}", headers: journalist_headers
+      put "/api/articles/#{article.id}",
+          params: { status: 'archived' },
+          headers: journalist_headers
     end
 
     it 'is expected to return status code 403' do
@@ -48,7 +54,7 @@ RSpec.describe 'DELETE /api/articles/:id' do
     end
 
     it 'is expected to return an error message' do
-      expect(response_json['error_message']).to eq 'You are not authorized to delete this article'
+      expect(response_json['error_message']).to eq 'You are not authorized to edit this article'
     end
   end
 end

--- a/spec/requests/api/editor/editor_can_put_backyard_articles_to_archive_spec.rb
+++ b/spec/requests/api/editor/editor_can_put_backyard_articles_to_archive_spec.rb
@@ -1,11 +1,12 @@
-RSpec.describe 'DELETE /api/articles/:id' do
+RSpec.describe 'PUT /api/articles/:id' do
   let(:article) { create(:backyard_article) }
   let(:editor) { create(:user, role: 'editor') }
   let(:editor_headers) { editor.create_new_auth_token }
 
   describe 'Successfully' do
     before do
-      delete "/api/backyards/#{article.id}", headers: editor_headers
+      put "/api/backyards/#{article.id}",
+          headers: editor_headers
     end
 
     it 'is expected to return status code 200' do
@@ -13,17 +14,18 @@ RSpec.describe 'DELETE /api/articles/:id' do
     end
 
     it 'is expected to return a success message' do
-      expect(response_json['message']).to eq 'The article was successfully deleted'
+      expect(response_json['message']).to eq 'This backyard article has been successfully archived'
     end
 
-    it 'is expected to have deleted article' do
-      expect(Article.all.count).to eq 0
+    it 'is expected to have archive article' do
+      expect(Article.where(status: 'archived').count).to eq 1
     end
   end
 
   describe 'Unsuccessfully because article does not exist' do
     before do
-      delete '/api/backyards/1337', headers: editor_headers
+      put "/api/backyards/#{article.id + 1}",
+          headers: editor_headers
     end
 
     it 'is expected to return status code 404' do
@@ -31,7 +33,7 @@ RSpec.describe 'DELETE /api/articles/:id' do
     end
 
     it 'is expected to return an error message' do
-      expect(response_json['error_message']).to eq "Couldn't find Article with 'id'=1337"
+      expect(response_json['error_message']).to eq "Couldn't find Article with 'id'=#{article.id+1}"
     end
   end
 
@@ -40,7 +42,8 @@ RSpec.describe 'DELETE /api/articles/:id' do
     let(:journalist_headers) { journalist.create_new_auth_token }
 
     before do
-      delete "/api/backyards/#{article.id}", headers: journalist_headers
+      put "/api/backyards/#{article.id}",
+          headers: journalist_headers
     end
 
     it 'is expected to return status code 403' do
@@ -48,7 +51,7 @@ RSpec.describe 'DELETE /api/articles/:id' do
     end
 
     it 'is expected to return an error message' do
-      expect(response_json['error_message']).to eq 'You are not authorized to delete this article'
+      expect(response_json['error_message']).to eq 'You are not authorized to archive this article'
     end
   end
 end

--- a/spec/requests/api/editor/editor_can_put_backyard_articles_to_archive_spec.rb
+++ b/spec/requests/api/editor/editor_can_put_backyard_articles_to_archive_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe 'PUT /api/articles/:id' do
+RSpec.describe 'PUT /api/backyards/:id' do
   let(:article) { create(:backyard_article) }
   let(:editor) { create(:user, role: 'editor') }
   let(:editor_headers) { editor.create_new_auth_token }
@@ -6,6 +6,9 @@ RSpec.describe 'PUT /api/articles/:id' do
   describe 'Successfully' do
     before do
       put "/api/backyards/#{article.id}",
+          params: {
+            status: 'archived'
+          },
           headers: editor_headers
     end
 
@@ -14,7 +17,7 @@ RSpec.describe 'PUT /api/articles/:id' do
     end
 
     it 'is expected to return a success message' do
-      expect(response_json['message']).to eq 'This backyard article has been successfully archived'
+      expect(response_json['message']).to eq 'This backyard article has been successfully updated'
     end
 
     it 'is expected to have archive article' do
@@ -25,6 +28,9 @@ RSpec.describe 'PUT /api/articles/:id' do
   describe 'Unsuccessfully because article does not exist' do
     before do
       put "/api/backyards/#{article.id + 1}",
+          params: {
+            status: 'archived'
+          },
           headers: editor_headers
     end
 
@@ -33,7 +39,7 @@ RSpec.describe 'PUT /api/articles/:id' do
     end
 
     it 'is expected to return an error message' do
-      expect(response_json['error_message']).to eq "Couldn't find Article with 'id'=#{article.id+1}"
+      expect(response_json['error_message']).to eq "Couldn't find Article with 'id'=#{article.id + 1}"
     end
   end
 
@@ -43,6 +49,9 @@ RSpec.describe 'PUT /api/articles/:id' do
 
     before do
       put "/api/backyards/#{article.id}",
+          params: {
+            status: 'archived'
+          },
           headers: journalist_headers
     end
 
@@ -51,7 +60,7 @@ RSpec.describe 'PUT /api/articles/:id' do
     end
 
     it 'is expected to return an error message' do
-      expect(response_json['error_message']).to eq 'You are not authorized to archive this article'
+      expect(response_json['error_message']).to eq 'You are not authorized to update this article'
     end
   end
 end

--- a/spec/requests/api/editor/editor_can_see_all_articles_spec.rb
+++ b/spec/requests/api/editor/editor_can_see_all_articles_spec.rb
@@ -26,8 +26,8 @@ RSpec.describe 'GET /api/articles', type: :request do
       expect(response_json['articles'].first['title']).to eq 'Third Article'
     end
 
-    it 'is expected to have a published status of true' do
-      expect(response_json['articles'].first['published']).to eq true
+    it 'is expected to have a status published' do
+      expect(response_json['articles'].first['status']).to eq 'Published'
     end
 
     it 'is expected to contain amount of comments connected to the article' do

--- a/spec/requests/api/editor/editor_can_see_company_statistics_spec.rb
+++ b/spec/requests/api/editor/editor_can_see_company_statistics_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe 'GET /api/statistics', type: :request do
   let!(:published_article2) { create(:article, created_at: Time.zone.now - 100_000)  }
   let!(:published_article3) { create(:article, created_at: Time.zone.now - 200_000)  }
   let!(:comment) { 3.times { create(:comment, article_id: published_article3.id, user_id: journalist.id) } }
-  let!(:unpublished_articles) { create(:article, published: false) }
+  let!(:draft_article) { create(:article, status: 'draft') }
+  let!(:archived_article) { create(:article, status: 'archived') }
   let!(:backyard_articles) { 3.times { create(:backyard_article) } }
   let!(:subscriptions_data) do
     file_fixture('stripe_stats.json').read
@@ -25,11 +26,11 @@ RSpec.describe 'GET /api/statistics', type: :request do
     end
 
     it 'is expected to return the total number of journalists' do
-      expect(response_json['statistics']['journalists']['total']).to eq 8
+      expect(response_json['statistics']['journalists']['total']).to eq 9
     end
 
     it 'is expected to return the total number of articles' do
-      expect(response_json['statistics']['articles']['total']).to eq 4
+      expect(response_json['statistics']['articles']['total']).to eq 5
     end
 
     it 'is expected to return the total number of published articles' do
@@ -37,7 +38,7 @@ RSpec.describe 'GET /api/statistics', type: :request do
     end
 
     it 'is expected to return the total number of unpublished articles' do
-      expect(response_json['statistics']['articles']['unpublished']).to eq 1
+      expect(response_json['statistics']['articles']['archived']).to eq 1
     end
 
     it 'is expected to return the total number of backyard articles' do

--- a/spec/requests/api/journalist/journalist_can_create_articles_spec.rb
+++ b/spec/requests/api/journalist/journalist_can_create_articles_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe 'POST /api/articles', type: :request do
     File.read(fixture_path + '/fake-news-fixture.txt')
   end
 
+  
   describe 'successfully' do
     before do
       post '/api/articles',

--- a/spec/requests/api/subscriber/can_write_backyard_articles_spec.rb
+++ b/spec/requests/api/subscriber/can_write_backyard_articles_spec.rb
@@ -28,6 +28,11 @@ RSpec.describe 'POST /api/backyards', type: :request do
       articles = Article.all.where(backyard: true)
       expect(articles.count).to eq 1
     end
+
+    it 'is expected to be published' do
+      articles = Article.all.where(backyard: true)
+      expect(articles.first.published?).to eq true
+    end
   end
 
   describe 'Unsuccessfully as a visitor' do

--- a/spec/requests/api/visitor/can_respond_with_list_of_articles_spec.rb
+++ b/spec/requests/api/visitor/can_respond_with_list_of_articles_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe 'GET /api/articles', type: :request do
     let!(:article1) { create(:article, title: 'Second Article', created_at: Time.zone.now - 100_000) }
     let!(:article2) { create(:article, title: 'First Article', created_at: Time.zone.now - 200_000) }
     let!(:article3) { create(:article, title: 'Third Article') }
-    let!(:unpublished_articles) { 2.times { create(:article, published: false) } }
+    let!(:unpublished_articles) { 2.times { create(:article, status: 'draft') } }
 
     before do
       get '/api/articles'

--- a/spec/requests/api/visitor/can_show_single_article_spec.rb
+++ b/spec/requests/api/visitor/can_show_single_article_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'GET /api/articles/:id' do
   let!(:subscriber2) { create(:user, role: 'subscriber') }
   let(:auth_headers2) { subscriber2.create_new_auth_token }
   let!(:article) { create(:article) }
-  let!(:unpublished_article) { create(:article, published: false) }
+  let!(:unpublished_article) { create(:article, status: 'draft') }
 
   describe 'successfully' do
     before do


### PR DESCRIPTION
PT: https://www.pivotaltracker.com/story/show/178319380
___
### User Story
```
As an owner
To avoid legal problems
I want to be able to archive articles instead of deleting them
```
___
### Changes Proposed
- Replaces attribute `published` to enum `status: {archived: 1, draft: 5, published: 10}`
- Refactors all index, show and create actions for articlees and backyard_article to use `ststus` enum
- Refactores delete actions into update actions that change `status` to `archived`  
___
### Lessons Learned
- working with `enum`
- how to refactor attributes of complex application where  those attributes are intertwined with different pieces of functionality