### PR TITLE
[BUG] Responds with normal article in SHOW /api/backyards/:id 

### DIFF
--- a/app/controllers/api/backyards_controller.rb
+++ b/app/controllers/api/backyards_controller.rb
@@ -15,7 +15,7 @@ class Api::BackyardsController < ApplicationController
     if backyard_article
       render json: backyard_article, serializer: BackyardsShowSerializerSerializer, root: :backyard_article
     else
-      render json: { error_message: "Couldn\'t find Article with 'id'=#{params[:id]}" }, status: 404
+      render json: { error_message: "Backyard Article with 'id'=#{params[:id]} does not exist" }, status: 404
     end
   end
 

--- a/app/controllers/api/backyards_controller.rb
+++ b/app/controllers/api/backyards_controller.rb
@@ -11,8 +11,12 @@ class Api::BackyardsController < ApplicationController
   end
 
   def show
-    backyard_article = Article.find(params[:id])
-    render json: backyard_article, serializer: BackyardsShowSerializerSerializer, root: :backyard_article
+    backyard_article = Article.where(id: params[:id], backyard: true).first
+    if backyard_article
+      render json: backyard_article, serializer: BackyardsShowSerializerSerializer, root: :backyard_article
+    else
+      render json: { error_message: "Couldn\'t find Article with 'id'=#{params[:id]}" }, status: 404
+    end
   end
 
   def create

--- a/spec/requests/api/visitor/can_respond_with_a_single_backyard_article_spec.rb
+++ b/spec/requests/api/visitor/can_respond_with_a_single_backyard_article_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe 'GET /api/backyards/:id', type: :request do
       expect(response).to have_http_status 404
     end
     it 'is expected to have error message' do
-      expect(response_json['error_message']).to eq "Couldn't find Article with 'id'=123"
+      expect(response_json['error_message']).to eq "Backyard Article with 'id'=123 does not exist"
     end
   end
 
@@ -50,7 +50,7 @@ RSpec.describe 'GET /api/backyards/:id', type: :request do
       expect(response).to have_http_status 404
     end
     it 'is expected to have error message' do
-      expect(response_json['error_message']).to eq "Couldn't find Article with 'id'=#{article.id}"
+      expect(response_json['error_message']).to eq "Backyard Article with 'id'=#{article.id} does not exist"
     end
   end
 end

--- a/spec/requests/api/visitor/can_respond_with_a_single_backyard_article_spec.rb
+++ b/spec/requests/api/visitor/can_respond_with_a_single_backyard_article_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe 'GET /api/backyards/:id', type: :request do
   let!(:backyard_article) { create(:backyard_article) }
+  let!(:article) { create(:article) }
 
   describe 'successfully' do
     before do
@@ -37,6 +38,19 @@ RSpec.describe 'GET /api/backyards/:id', type: :request do
     end
     it 'is expected to have error message' do
       expect(response_json['error_message']).to eq "Couldn't find Article with 'id'=123"
+    end
+  end
+
+  describe 'unsuccessfully, with non-backyrd article :id' do
+    before do
+      get "/api/backyards/#{article.id}"
+    end
+
+    it 'is expected to return 404 status' do
+      expect(response).to have_http_status 404
+    end
+    it 'is expected to have error message' do
+      expect(response_json['error_message']).to eq "Couldn't find Article with 'id'=#{article.id}"
     end
   end
 end


### PR DESCRIPTION
PT: https://www.pivotaltracker.com/story/show/178353916

### Description
A SHOW request to /backyards  can actually respond with a normal article, but rendered through BackyardSerializer
### Changes Proposed
- replace Article.find(:id) with .where(:id, backyard: true)
- adds condition to provide error handing
- adds test for found bug