### PR TITLE
Can't update image bug // Backyard shows archived articles bug

### DIFF
--- a/app/controllers/api/articles_controller.rb
+++ b/app/controllers/api/articles_controller.rb
@@ -102,6 +102,7 @@ class Api::ArticlesController < ApplicationController
   end
 
   def update_article(article)
+    attach_image(article)
     updated_article = article.update(article_params)
     if updated_article
       render json: { message: 'Your article has been successfully updated!' }, status: 200

--- a/app/controllers/api/backyards_controller.rb
+++ b/app/controllers/api/backyards_controller.rb
@@ -5,14 +5,19 @@ class Api::BackyardsController < ApplicationController
 
   def index
     country = get_country
-    backyard_articles = Article.where(location: country).most_recent
+    backyard_articles = Article.where(location: country, status: 'published').most_recent
     render json: backyard_articles, each_serializer: BackyardsIndexSerializer, root: :backyard_articles,
            meta: country, meta_key: :location
   end
 
   def show
     backyard_article = Article.find(params[:id])
-    render json: backyard_article, serializer: BackyardsShowSerializerSerializer, root: :backyard_article
+
+    if backyard_article.published?
+      render json: backyard_article, serializer: BackyardsShowSerializerSerializer, root: :backyard_article
+    else
+      render json: { error_message: 'This article does not exist' }, status: 404
+    end
   end
 
   def create

--- a/spec/requests/api/journalist/journalist_can_edit_their_own_article_spec.rb
+++ b/spec/requests/api/journalist/journalist_can_edit_their_own_article_spec.rb
@@ -47,6 +47,33 @@ RSpec.describe 'PUT /api/articles/:id', type: :request do
     end
   end
 
+  describe 'successfully by only changing the picture' do
+    let(:image) do
+      File.read(fixture_path + '/fake-news-fixture.txt')
+    end
+    before do
+      put "/api/articles/#{article.id}",
+          params: {
+            article: {
+             image: image
+            }
+          },
+          headers: auth_headers
+    end
+
+    it 'is expected to response with status 200' do
+      expect(response).to have_http_status 200
+    end
+
+    it 'is expected to respond with message' do
+      expect(response_json['message']).to eq 'Your article has been successfully updated!'
+    end
+
+    it 'is expected to have the new image attached' do
+      expect(updated_article.image).not_to eq article.image
+    end
+  end
+
   describe 'unsuccessfully, article does not exist' do
     before do
       put "/api/articles/#{article.id + 1}",

--- a/spec/requests/api/visitor/can_respond_with_a_single_backyard_article_spec.rb
+++ b/spec/requests/api/visitor/can_respond_with_a_single_backyard_article_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'GET /api/backyards/:id', type: :request do
     end
   end
 
-  describe 'unsuccessfully' do
+  describe 'unsuccessfully with non-existent article' do
     before do
       get '/api/backyards/123'
     end
@@ -37,6 +37,21 @@ RSpec.describe 'GET /api/backyards/:id', type: :request do
     end
     it 'is expected to have error message' do
       expect(response_json['error_message']).to eq "Couldn't find Article with 'id'=123"
+    end
+  end
+
+  describe 'unsuccessfully if the article is archived' do
+    let!(:archived_backyard_article) { create(:backyard_article, status: 'archived') }
+    before do
+      get "/api/backyards/#{archived_backyard_article.id}"
+    end
+
+    it 'is expected to response with status 404' do
+      expect(response).to have_http_status 404
+    end
+
+    it 'is expected to have error message' do
+      expect(response_json['error_message']).to eq "This article does not exist"
     end
   end
 end

--- a/spec/requests/api/visitor/can_respond_with_list_of_backyard_articles_spec.rb
+++ b/spec/requests/api/visitor/can_respond_with_list_of_backyard_articles_spec.rb
@@ -3,10 +3,11 @@ RSpec.describe 'GET /api/backyards', type: :request do
   let(:vistor_location) do
     file_fixture('visitor_location.json').read
   end
- 
-
+  
+  
   describe 'Successfully' do
     let!(:backyard_articles) { 3.times { create(:backyard_article) } }
+    let!(:backyard_article_archived) { create(:backyard_article, location: 'Sweden', status: 'archived') }
     before do
       stub_request(:get, 'https://nominatim.openstreetmap.org/reverse?accept-language=en&addressdetails=1&format=json&lat=59.32021&lon=18.37827')
       .with(
@@ -24,7 +25,7 @@ RSpec.describe 'GET /api/backyards', type: :request do
       expect(response).to have_http_status 200
     end
   
-    it 'is expected to respond with a list of 3 articles' do
+    it 'is expected to respond with a list of 3 published articles' do
       expect(response_json['backyard_articles'].count).to eq 3
     end
   


### PR DESCRIPTION
[PT Story](https://www.pivotaltracker.com/story/show/178358305)

## Changes proposed
* Adds functionality so that an image can actually be changed
* Restricts archived backyard articles from being accessible